### PR TITLE
interaction issue caused by ordering of passenger's mod_dir block

### DIFF
--- a/ext/apache2/Hooks.cpp
+++ b/ext/apache2/Hooks.cpp
@@ -1742,7 +1742,7 @@ passenger_register_hooks(apr_pool_t *p) {
 	ap_hook_fixups(save_state_before_rewrite_rules, NULL, rewrite_module, APR_HOOK_LAST);
 	ap_hook_fixups(undo_redirection_to_dispatch_cgi, rewrite_module, NULL, APR_HOOK_FIRST);
 	ap_hook_fixups(start_blocking_mod_dir, NULL, dir_module, APR_HOOK_MIDDLE);
-	ap_hook_fixups(end_blocking_mod_dir, dir_module, NULL, APR_HOOK_MIDDLE);
+	ap_hook_fixups(end_blocking_mod_dir, dir_module, NULL, APR_HOOK_LAST);
 	
 	ap_hook_handler(handle_request_when_in_high_performance_mode, NULL, NULL, APR_HOOK_FIRST);
 	ap_hook_handler(start_blocking_mod_autoindex, NULL, autoindex_module, APR_HOOK_LAST);


### PR DESCRIPTION
_(This is my first "pull request": I therefore simply copied my commit message, as that seemed sufficient.)_

**Fix "crude" hook calling order of end_blocking_mod_dir to have parity with Apache's mod_dir.**

When Passenger's end_blocking_mod_dir hook is executed, all of its "pre" dependencies, in this case mod_dir, are executed immediately. Unfortunately, this means that mod_dir, which is normally a very low priority HOOK_LAST, gets bumped up to HOOK_MIDDLE when mod_passenger is installed (even if it is inactive, and even if the hooks are totally neutered).

This breaks any other existing web applications (such as a mod_python installation) that are relying on being able to execute before mod_dir by having registered as HOOK_MIDDLE. To fix this, the flags for hooks dependent on mod_dir have been updated to match the calling order of the underlying module from Apache.

(As I do not have a similar issue with mod_autoindex I have not adjusted end_blocking_mod_autoindex to HOOK_MIDDLE; however, it should probably be looked at again, keeping this issue in mind.)
