### PR TITLE
Passenger 624

### DIFF
--- a/lib/phusion_passenger/utils.rb
+++ b/lib/phusion_passenger/utils.rb
@@ -57,7 +57,7 @@ protected
 		raise ArgumentError, "The 'path' argument may not be nil" if path.nil?
 		return Pathname.new(path).realpath.to_s
 	rescue Errno::ENOENT => e
-		raise InvalidAPath, e.message
+		raise InvalidPath, e.message
 	end
 	
 	# Assert that +path+ is a directory. Raises +InvalidPath+ if it isn't.


### PR DESCRIPTION
Fixed mis-typed constant name. This code is hit when the passenger directory doesn't exist.

Ticket is here: http://code.google.com/p/phusion-passenger/issues/detail?id=624
