### PR TITLE
Fix build of LoggingAgent's FilterSupport

### DIFF
--- a/ext/common/LoggingAgent/FilterSupport.h
+++ b/ext/common/LoggingAgent/FilterSupport.h
@@ -35,6 +35,7 @@
 #include <set>
 #include <regex.h>
 #include <cstring>
+#include <stdio.h>
 
 #include <StaticString.h>
 #include <Exceptions.h>


### PR DESCRIPTION
While compiling the apache2 module, I was seeing errors due to `printf` being undefined in the scope of FilterSupport.

This commit just includes `stdio.h` to ensure the `printf` is defined.
