### PR TITLE
Prevent PPC architecture(s) from being targeted on Leopard/Snow Leopard

### DIFF
--- a/lib/phusion_passenger/platform_info/apache.rb
+++ b/lib/phusion_passenger/platform_info/apache.rb
@@ -215,9 +215,8 @@ module PlatformInfo
 				architectures = ["-arch i386 -arch ppc -arch x86_64 -arch ppc64"]
 			else
 				architectures = []
-				output.split("\n").grep(/for architecture/).each do |line|
-					line =~ /for architecture (.*?)\)/
-					architectures << "-arch #{$1}"
+				output.scan(/for architecture (.*?)\)/).each do |(arch)|
+					architectures << "-arch #{arch}" unless arch =~ /ppc/
 				end
 			end
 			flags << architectures.compact.join(' ')


### PR DESCRIPTION
Xcode 4 doesn't support PPC, so Passenger is unable to be built with Xcode 4 unless a patch like this is applied.
