### PR TITLE
Issue 653 & 655

### DIFF
--- a/lib/phusion_passenger/platform_info/apache.rb
+++ b/lib/phusion_passenger/platform_info/apache.rb
@@ -274,7 +274,7 @@ module PlatformInfo
 	# headers are placed into the same directory as the Apache headers,
 	# and so 'apr-config' and 'apu-config' won't be necessary in that case.
 	def self.apr_config_needed_for_building_apache_modules?
-		filename = File.join("#{test_exe_outdir}/passenger-platform-check-#{Process.pid}.c")
+		filename = File.join("#{tmpexedir}/passenger-platform-check-#{Process.pid}.c")
 		File.open(filename, "w") do |f|
 			f.puts("#include <apr.h>")
 		end


### PR DESCRIPTION
This patch fixes an issue introduced in e6a7efd915eb077fb733819b3f2b7fa18117b758 it's just a typo in the variable name that crashes the Apache installer.

Also added a comment to issues [653](https://code.google.com/p/phusion-passenger/issues/detail?id=653) and [655](https://code.google.com/p/phusion-passenger/issues/detail?id=655).
