### PR TITLE
nginx: look for index.html in all paths ending in '/'

### DIFF
--- a/ext/nginx/ContentHandler.c
+++ b/ext/nginx/ContentHandler.c
@@ -165,6 +165,16 @@ map_uri_to_page_cache_file(ngx_http_request_t *r, ngx_str_t *public_dir,
         }
         end = ngx_copy(end, "index.html", sizeof("index.html"));
         
+    } else if (filename[filename_len - 1] == '/') {
+        /* if the filename ends with '/' check for filename + "index.html". */
+        
+        if (filename_len + sizeof("index.html") > page_cache_file->len) {
+            /* Page cache filename doesn't fit in the buffer. */
+            return 0;
+        }
+        
+        end = ngx_copy(page_cache_file->data, filename, filename_len);
+        end = ngx_copy(end, "index.html", sizeof("index.html"));
     } else {
         /* Otherwise, the page cache file is just filename + ".html". */
         


### PR DESCRIPTION
See mailing list thread: http://groups.google.com/group/phusion-passenger/browse_thread/thread/58453ce1ea4c60c4

I'm not much of a C programmer ... so I added the bare minimum to get this working for me.

Start to match the behavior of the Apache2 handling of
requests that might be in the pageCache.

If the filename ends with '/' try to serve filename + 'index.html

The Apache2 handler also checks 'index/htm'

