### PR TITLE
Fixed the following error I had with passenger package-runtime from gem..

### DIFF
--- a/lib/phusion_passenger/standalone/runtime_installer.rb
+++ b/lib/phusion_passenger/standalone/runtime_installer.rb
@@ -220,6 +220,9 @@ private
 		
 		max_width = 79
 		progress_bar_width = 45
+
+                total_progress = total_progress.abs
+
 		text = sprintf("[%-#{progress_bar_width}s] %s",
 			'*' * (progress_bar_width * total_progress).to_i,
 			status_text)


### PR DESCRIPTION
Fixed the following error I had with passenger package-runtime from gem...
$HOME/.rvm/gems/ruby-1.8.7-head@gemset/gems/passenger-3.0.7/lib/phusion_passenger/standalone/runtime_installer.rb:224:in `*': negative argument (ArgumentError)

See https://gist.github.com/987482

total_progress in show_progress method was increasing negatively

Snow Leopard
Ruby 1.8.7-p334
passenger installed as gem
