### PR TITLE
Include Rake::DSL if defined for Rake 0.9 compat

### DIFF
--- a/misc/rake/extensions.rb
+++ b/misc/rake/extensions.rb
@@ -104,6 +104,11 @@ def subdir(dir, &block)
 end
 
 class Subdir # :nodoc:
+	# Rake 0.9 compatibility since methods like <tt>task<tt> and <tt>desc</tt>
+	# aren't available in Object anymore.
+	# See: https://github.com/jimweirich/rake/issues/33#issuecomment-1213705
+	include Rake::DSL if defined?(Rake::DSL)
+	
 	def initialize(dir)
 		@dir = dir
 		@toplevel_dir = Pathname.getwd


### PR DESCRIPTION
Includes the `Rake::DSL` module into `RakeExtensions::Subdir` when defined.
- standard methods not defined on Object as of 0.9
- only include if defined, so backwards compatible with Rake 0.8

This fixes an error when compiling modules when Rake 0.9 is installed.

The error manifested itself as the `desc` method not being defined in `Rakefile` line 590.

NOTE: This is probably an issue with newer versions of Passenger as well. A similar fix can be used.

See @jimweirich's comments at https://github.com/jimweirich/rake/issues/33#issuecomment-1213705
