### PR TITLE
Replace /opt/ruby-enterprise/bin/ruby with /usr/bin/ruby in shebangs of some test files

### DIFF
--- a/test/stub/rails_apps/1.2/empty/public/dispatch.cgi
+++ b/test/stub/rails_apps/1.2/empty/public/dispatch.cgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 

--- a/test/stub/rails_apps/1.2/empty/public/dispatch.fcgi
+++ b/test/stub/rails_apps/1.2/empty/public/dispatch.fcgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 #
 # You may specify the path to the FastCGI crash log (a log of unhandled
 # exceptions which forced the FastCGI instance to exit, great for debugging)

--- a/test/stub/rails_apps/1.2/empty/public/dispatch.rb
+++ b/test/stub/rails_apps/1.2/empty/public/dispatch.rb
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 

--- a/test/stub/rails_apps/2.0/empty/public/dispatch.cgi
+++ b/test/stub/rails_apps/2.0/empty/public/dispatch.cgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 

--- a/test/stub/rails_apps/2.0/empty/public/dispatch.fcgi
+++ b/test/stub/rails_apps/2.0/empty/public/dispatch.fcgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 #
 # You may specify the path to the FastCGI crash log (a log of unhandled
 # exceptions which forced the FastCGI instance to exit, great for debugging)

--- a/test/stub/rails_apps/2.0/empty/public/dispatch.rb
+++ b/test/stub/rails_apps/2.0/empty/public/dispatch.rb
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 

--- a/test/stub/rails_apps/2.2/empty/public/dispatch.cgi
+++ b/test/stub/rails_apps/2.2/empty/public/dispatch.cgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 

--- a/test/stub/rails_apps/2.2/empty/public/dispatch.fcgi
+++ b/test/stub/rails_apps/2.2/empty/public/dispatch.fcgi
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 #
 # You may specify the path to the FastCGI crash log (a log of unhandled
 # exceptions which forced the FastCGI instance to exit, great for debugging)

--- a/test/stub/rails_apps/2.2/empty/public/dispatch.rb
+++ b/test/stub/rails_apps/2.2/empty/public/dispatch.rb
@@ -1,4 +1,4 @@
-#!/opt/ruby-enterprise/bin/ruby
+#!/usr/bin/ruby
 
 require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)
 


### PR DESCRIPTION
I use gem2rpm to create RPMs from gems so I can deploy more easily.

Some tests in test/stub/rails_apps have /opt/ruby-enterprise/bin/ruby in the shebangs. This causes the rpm build process to pull in /opt/ruby-enterprise/bin/ruby as a dependency (which is not desireable!)

This diff simply replaces  /opt/ruby-enterprise/bin/ruby with /usr/bin/ruby.
