### PR TITLE
Show group name instead of app root

### DIFF
--- a/lib/phusion_passenger/classic_rails/application_spawner.rb
+++ b/lib/phusion_passenger/classic_rails/application_spawner.rb
@@ -172,7 +172,7 @@ protected
 	# Overrided method.
 	def initialize_server # :nodoc:
 		report_app_init_status(MessageChannel.new(@owner_socket)) do
-			$0 = "Passenger ApplicationSpawner: #{@app_root}"
+			$0 = "Passenger ApplicationSpawner: #{@options['app_group_name']}"
 			prepare_app_process('config/environment.rb', @options)
 			if defined?(RAILS_ENV)
 				Object.send(:remove_const, :RAILS_ENV)
@@ -299,7 +299,7 @@ private
 	# used).
 	def self.start_request_handler(channel, forked, options)
 		app_root = options["app_root"]
-		$0 = "Rails: #{app_root}"
+		$0 = "Rails: #{options['app_group_name']}"
 		reader, writer = IO.pipe
 		begin
 			reader.close_on_exec!

--- a/lib/phusion_passenger/rack/application_spawner.rb
+++ b/lib/phusion_passenger/rack/application_spawner.rb
@@ -151,7 +151,7 @@ protected
 	# Overrided method.
 	def initialize_server # :nodoc:
 		report_app_init_status(MessageChannel.new(@owner_socket)) do
-			$0 = "Passenger ApplicationSpawner: #{@app_root}"
+			$0 = "Passenger ApplicationSpawner: #{@options['app_group_name']}"
 			prepare_app_process('config.ru', @options)
 			@app = self.class.send(:load_rack_app)
 			after_loading_app_code(@options)
@@ -189,7 +189,7 @@ private
 
 	def self.start_request_handler(channel, app, forked, options)
 		app_root = options["app_root"]
-		$0 = "Rack: #{app_root}"
+		$0 = "Rack: #{options['app_group_name']}"
 		reader, writer = IO.pipe
 		begin
 			reader.close_on_exec!

--- a/lib/phusion_passenger/wsgi/application_spawner.rb
+++ b/lib/phusion_passenger/wsgi/application_spawner.rb
@@ -70,7 +70,7 @@ class ApplicationSpawner
 
 private
 	def run(channel, options)
-		$0 = "WSGI: #{options['app_root']}"
+		$0 = "WSGI: #{options['app_group_name']}"
 		prepare_app_process("passenger_wsgi.py", options)
 		ENV['WSGI_ENV'] = options['environment']
 		


### PR DESCRIPTION
Show the group name in processes instead of app root.  The group name defaults to app root anyway, unless you set to explicitly with PassengerAppGroupName.
