### PR TITLE
Only prepend LIBDIR to the load path if it's truly missing

### DIFF
--- a/lib/phusion_passenger/utils.rb
+++ b/lib/phusion_passenger/utils.rb
@@ -330,7 +330,7 @@ protected
 		# attempt to un-require RubyGems, so here we put Phusion Passenger back
 		# into the load path. This must be done before loading the app's startup
 		# file because the app might require() Phusion Passenger files.
-		if $LOAD_PATH.first != LIBDIR
+		if not $LOAD_PATH.include?(LIBDIR)
 			$LOAD_PATH.unshift(LIBDIR)
 			$LOAD_PATH.uniq!
 		end


### PR DESCRIPTION
Forcing LIBDIR to be the first item on the load path means that if passenger has been installed as a package in the main ruby library directory then the rack (if any) in that directory will always be used regardless of what the Gemfile may ask for.

With this patch LIBDIR is only prepended to the load path if it is not present anywhere on the existing path, rather than if it isn't the first thing on the path. This allows any rack gem added to the path by bundler to take precedence over one in LIBDIR.
