### PR TITLE
fix rackupfile include non ascii char on ruby1.9 environment

### DIFF
--- a/lib/phusion_passenger/rack/application_spawner.rb
+++ b/lib/phusion_passenger/rack/application_spawner.rb
@@ -218,7 +218,7 @@ private
 		# Rails apps explicitly specify a Rack version as dependency.
 		require 'rack'
 		rackup_file = ENV["RACKUP_FILE"] || "config.ru"
-		rackup_code = ::File.read(rackup_file)
+		rackup_code = ::File.read(rackup_file, File.size(rackup_file)) # binary reading for non ascii char
 		eval("Rack::Builder.new {( #{rackup_code}\n )}.to_app", TOPLEVEL_BINDING, rackup_file)
 	end
 	private_class_method :load_rack_app


### PR DESCRIPTION
When I use this rackupfile on Ruby1.9
https://gist.github.com/1275112

Then cause "Exception ArgumentError in spawn manager (invalid byte sequence in US-ASCII)"

Because file read as "textmode", and encoding is not set.

I fixed this problem.
