### PR TITLE
Prespawn script should always connect to localhost

### DIFF
--- a/helper-scripts/prespawn
+++ b/helper-scripts/prespawn
@@ -102,7 +102,7 @@ class TCPPrespawnLocation < PrespawnLocation
 	end
 
 	def connect
-		TCPSocket.new(request_host, request_port)
+		TCPSocket.new('127.0.0.1', request_port)
 	end
 end
 


### PR DESCRIPTION
Contrary to what is written in the documentation of Passenger, the prespawn script helper that is used for the `PassengerPreStart` directive does not always connect to localhost. It tries to look up the hostname in the given URL in case of HTTP connections, which may fail in some setups.

It appears this behaviour was accidentally changed in this commit: https://github.com/FooBarWidget/passenger/commit/8e34d3e6c8fc1af7e13495df792b67115422adf7

This patch reverts the behaviour to version 3.0.7 of Passenger and before, where any request is issues against localhost.
