### PR TITLE
Use 127.0.0.1 as the destination for the TCPSocket connections.

### DIFF
--- a/helper-scripts/prespawn
+++ b/helper-scripts/prespawn
@@ -102,7 +102,7 @@ class TCPPrespawnLocation < PrespawnLocation
 	end
 
 	def connect
-		TCPSocket.new(request_host, request_port)
+		TCPSocket.new('127.0.0.1', request_port)
 	end
 end
 


### PR DESCRIPTION
A bug has crept into the prespawn script where it currently makes the request to the host provided in the URI, instead of to the local machine. I've re-added the explicit 127.0.0.1 destination for the request, in order to match both the previous code and the documentation.
