### PR TITLE
Improve upload error reporting

### DIFF
--- a/ext/apache2/Hooks.cpp
+++ b/ext/apache2/Hooks.cpp
@@ -874,6 +874,11 @@ private:
 				e.backtrace());
 			return HTTP_INTERNAL_SERVER_ERROR;
 			
+		} catch (const UploadException &e) {
+			if (e.hasMessage())
+				P_ERROR(e.what() << "\n");
+			return e.getHttpStatus();
+		
 		} catch (const tracable_exception &e) {
 			P_ERROR("Unexpected error in mod_passenger: " <<
 				e.what() << "\n" << "  Backtrace:\n" << e.backtrace());
@@ -1242,7 +1247,7 @@ private:
 					rv);
 			}
 			message[sizeof(message) - 1] = '\0';
-			throw RuntimeException(message);
+			throw UploadException(message);
 		}
 		
 		/* If this fails, it means that a filter is written incorrectly and that

--- a/ext/apache2/Hooks.cpp
+++ b/ext/apache2/Hooks.cpp
@@ -101,6 +101,25 @@ extern "C" module AP_MODULE_DECLARE_DATA passenger_module;
 
 
 /**
+ * Exception during upload.
+ *
+ * @ingroup Exceptions
+ */
+class UploadException: public std::exception {
+private:
+	string msg;
+	int http_status;
+public:
+	UploadException(const string &message, int status = HTTP_INTERNAL_SERVER_ERROR)
+		: msg(message), http_status(status) {}
+	UploadException(int status): msg(""), http_status(status) {}
+	virtual ~UploadException() throw() {}
+	virtual const char *what() const throw() { return msg.c_str(); }
+	bool hasMessage() const throw() { return !msg.empty(); }
+	int getHttpStatus() const throw() { return http_status; }
+};
+
+/**
  * Apache hook functions, wrapped in a class.
  *
  * @ingroup Core


### PR DESCRIPTION
re: issue 723 (https://code.google.com/archive/p/phusion-passenger/issues/723)

Posted on Nov 24, 2011 by Swift Kangaroo
I prepared patches to improve error reporting during HTTP upload.

Currently all errors during HTTP upload result in status 500 written to access.log and "Unexpected error in mod_passenger" message in main error.log

My patches fix error reporting for: 1) request body limit exceeded - logged with status 413, 2) timeout errors (result of mod_reqtimeout) or connection reset - logged with status 408, correct error document is sent to client