### PR TITLE
exposing read_timeout parameters in nginx config

### DIFF
--- a/ext/nginx/Configuration.c
+++ b/ext/nginx/Configuration.c
@@ -1319,6 +1319,13 @@ const ngx_command_t passenger_commands[] = {
       offsetof(passenger_loc_conf_t, upstream_config.busy_buffers_size_conf),
       NULL },
 
+    { ngx_string("passenger_read_timeout"),
+      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(passenger_loc_conf_t, upstream_config.read_timeout),
+      NULL },
+       
     { ngx_string("passenger_spawn_method"),
       NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,

--- a/test/integration_tests/nginx_tests.rb
+++ b/test/integration_tests/nginx_tests.rb
@@ -194,9 +194,10 @@ describe "Phusion Passenger for Nginx" do
 				server[:passenger_show_version_in_header] = "off"
 			end
 			@nginx.add_server do |server|
-				server[:server_name] = "2.passenger.test"
-				server[:root]        = "#{@stub.full_app_root}/public"
+				server[:server_name]            = "2.passenger.test"
+				server[:root]                   = "#{@stub.full_app_root}/public"
 				server[:passenger_max_requests] = 3
+				server[:passenger_read_timeout] = '3000ms'
 			end
 			@nginx.start
 		end
@@ -260,6 +261,18 @@ describe "Phusion Passenger for Nginx" do
 			get("/pid").should == pid
 			get("/pid").should_not == pid
 		end
+		
+		it "respects read_timeout setting" do
+			@server = "http://2.passenger.test:#{@nginx.port}/"
+
+			response = get_response('/?sleep_seconds=1')
+			response["Status"].should == "200"
+
+			response = get_response('/?sleep_seconds=5')
+			# response["Status"].should == "504" doesn't work???
+			response.class.should == Net::HTTPGatewayTimeOut 
+		end
+		
 	end
 	
 	

--- a/test/stub/rack/config.ru
+++ b/test/stub/rack/config.ru
@@ -1,3 +1,5 @@
+require 'cgi'
+
 app = lambda do |env|
     if env['PATH_INFO'] == '/chunked'
         chunks = ["7\r\nchunk1\n\r\n", "7\r\nchunk2\n\r\n", "7\r\nchunk3\n\r\n", "0\r\n\r\n"]
@@ -5,6 +7,11 @@ app = lambda do |env|
     elsif env['PATH_INFO'] == '/pid'
         [200, { "Content-Type" => "text/html" }, [$$]]
     else
+        params = CGI.parse(env['QUERY_STRING'])
+        if params['sleep_seconds'].first
+          sleep params['sleep_seconds'].first.to_f
+        end
+      
         [200, { "Content-Type" => "text/html" }, ["hello <b>world</b>"]]
     end
 end


### PR DESCRIPTION
Passenger currently responds with 504 when the server takes longer than 10 minutes (read_timeout). Although this is an option internally, it is not exposed to be configured via nginx config.

I'm re-using passenger for long running tasks and in certain rare cases it is needed for this timeout to be longer. It seems other may run into this limitation from time to time as well (http://groups.google.com/group/phusion-passenger/browse_thread/thread/2ce11bef1fa7032d). 

This is a simple change that exposes the read_timeout to the nginx config. Included is the change with a test to ensure the parameter works. I did not change the documentation for nginx, however, as in general 10 min timeout is appropriate.

I tested an hour timeout with nginx 1.0.10 and it worked fine.
