### PR TITLE
Include http_gzip_static_module when configuring nginx 

### DIFF
--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -392,6 +392,7 @@ private
 	def build_nginx_configure_command(prefix, extra_configure_flags = nil)
 		command = "sh ./configure --prefix='#{prefix}' "
 		command << "--with-http_ssl_module "
+		command << "--with-http_gzip_static_module "
 		command << "--with-cc-opt='-Wno-error' "
 		if @pcre_source_dir
 			command << "--with-pcre='#{@pcre_source_dir}' "


### PR DESCRIPTION
It's an optional nginx module that serves precompressed versions of static files. This is useful for the Rails asset pipeline, because the asset recompilation process already generates pre compressed files. To enable it in the nginx config add the following directive: "gzip_static on;"
