### PR TITLE
Fix for issue #563 (Rails page cache outside public/ is not served by Apache (but improperly forwarded to the Rails app))

### DIFF
--- a/ext/apache2/Hooks.cpp
+++ b/ext/apache2/Hooks.cpp
@@ -150,7 +150,8 @@ private:
 		char *filenameBeforeModRewrite;
 		apr_filetype_e oldFileType;
 		const char *handlerBeforeModAutoIndex;
-		
+                bool skipBackend;
+
 		RequestNote(const DirectoryMapper &m, DirConfig *c)
 			: mapper(m),
 			  config(c)
@@ -160,8 +161,8 @@ private:
 			filenameBeforeModRewrite  = NULL;
 			oldFileType               = APR_NOFILE;
 			handlerBeforeModAutoIndex = NULL;
+                        skipBackend               = false;
 		}
-		
 		~RequestNote() {
 			delete errorReport;
 		}
@@ -449,6 +450,11 @@ private:
 			FileType fileType = getFileType(filename);
 			if (fileType == FT_REGULAR) {
 				// (C) is true.
+				RequestNote *note = getRequestNote(r);
+				if (note != NULL) {
+					// We were prepared to handle the request, but we should not
+                                        note->skipBackend = true;
+				}
 				return false;
 			}
 			
@@ -525,7 +531,7 @@ private:
 		 */
 		
 		RequestNote *note = getRequestNote(r);
-		if (note == NULL) {
+		if (note == NULL || (note->skipBackend == true)) {
 			return DECLINED;
 		} else if (note->errorReport != NULL) {
 			/* Did an error occur in any of the previous hook methods during


### PR DESCRIPTION
As I wasn't sure how to clear an existing RequestNote / userdata APR pool, I've added a skipBackend flag to the RequestNote.

This solves the issue, as for some reason the requests that needs to be served from the page cache goes 3 times in prepareRequest(): a RequestNote is created on a previous pass, which makes handleRequest() believe that it needs to be served by Rails.
