### PR TITLE
Include last_used in process status xml

### DIFF
--- a/ext/common/ApplicationPool/Pool.h
+++ b/ext/common/ApplicationPool/Pool.h
@@ -478,6 +478,7 @@ private:
 		result << "<sessions>" << processInfo->sessions << "</sessions>";
 		result << "<processed>" << processInfo->processed << "</processed>";
 		result << "<uptime>" << processInfo->uptime() << "</uptime>";
+		result << "<last_used>" << processInfo->lastUsed << "</last_used>";
 		if (processInfo->metrics.isValid()) {
 			const ProcessMetrics &metrics = processInfo->metrics;
 			result << "<has_metrics>true</has_metrics>";


### PR DESCRIPTION
last_used can be used to determine when an active request started, or how long
ago the last request finished. This can be interesting for monitoring
purposes.
