### PR TITLE
Remove Passenger version from Server header

### DIFF
--- a/ext/nginx/ContentHandler.c
+++ b/ext/nginx/ContentHandler.c
@@ -1197,8 +1197,10 @@ process_header(ngx_http_request_t *r)
     ngx_table_elt_t                *h;
     ngx_http_upstream_header_t     *hh;
     ngx_http_upstream_main_conf_t  *umcf;
+    passenger_loc_conf_t           *slcf;
 
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
+    slcf = ngx_http_get_module_loc_conf(r, ngx_http_passenger_module);
 
     for ( ;;  ) {
 
@@ -1278,7 +1280,11 @@ process_header(ngx_http_request_t *r)
 
                 h->key.len = sizeof("Server") - 1;
                 h->key.data = (u_char *) "Server";
-                h->value.data = (u_char *) (NGINX_VER " + Phusion Passenger " PASSENGER_VERSION " (mod_rails/mod_rack)");
+                if( slcf->show_version_in_header == 0 ) {
+                    h->value.data = (u_char *) (NGINX_VER);
+                } else {
+                    h->value.data = (u_char *) (NGINX_VER " + Phusion Passenger " PASSENGER_VERSION " (mod_rails/mod_rack)");
+                }
                 h->value.len = ngx_strlen(h->value.data);
                 h->lowcase_key = (u_char *) "server";
             }


### PR DESCRIPTION
Since the option is called show_version_in_header i think there is a discrepancy in the behaviour of the module. It removes the "X-Powered-By" header but not the passenger version part from the "Server" header as the user expects.
