### PR TITLE
Fix version number in Constants.h

### DIFF
--- a/ext/common/Constants.h
+++ b/ext/common/Constants.h
@@ -26,7 +26,7 @@
 #define _PASSENGER_CONSTANTS_H_
 
 /* Don't forget to update lib/phusion_passenger.rb too. */
-#define PASSENGER_VERSION "3.0.11"
+#define PASSENGER_VERSION "3.0.12"
 
 #define FEEDBACK_FD 3
 


### PR DESCRIPTION
Fix incorrect version number in Constants.h that prevents installing as gem
