### PR TITLE
Fix boost threads detection when compiling passenger with gcc 4.7

### DIFF
--- a/ext/boost/config/stdlib/libstdcpp3.hpp
+++ b/ext/boost/config/stdlib/libstdcpp3.hpp
@@ -31,7 +31,8 @@
 
 #ifdef __GLIBCXX__ // gcc 3.4 and greater:
 #  if defined(_GLIBCXX_HAVE_GTHR_DEFAULT) \
-        || defined(_GLIBCXX__PTHREADS)
+        || defined(_GLIBCXX__PTHREADS) \
+        || defined(_GLIBCXX_HAS_GTHREADS)
       //
       // If the std lib has thread support turned on, then turn it on in Boost
       // as well.  We do this because some gcc-3.4 std lib headers define _REENTANT


### PR DESCRIPTION
This is a fix for issue #747 according to https://svn.boost.org/trac/boost/ticket/6165.
