### PR TITLE
Add missing depcomp script used during compilation

### DIFF
--- a/lib/phusion_passenger/packaging.rb
+++ b/lib/phusion_passenger/packaging.rb
@@ -73,7 +73,7 @@ module Packaging
 		'ext/boost/**/*',
 		'ext/libev/{LICENSE,Changes,README,Makefile.am,Makefile.in}',
 		'ext/libev/{*.m4,autogen.sh,config.guess,config.h.in,config.sub}',
-		'ext/libev/{configure,configure.ac,install-sh,ltmain.sh,missing,mkinstalldirs}',
+		'ext/libev/{configure,configure.ac,depcomp,install-sh,ltmain.sh,missing,mkinstalldirs}',
 		'ext/libev/{*.h,*.c}',
 		'ext/libeio/{LICENSE,Changes,README,Makefile.am,Makefile.in}',
 		'ext/libeio/{*.m4,autogen.sh,config.guess,config.h.in,config.sub}',


### PR DESCRIPTION
When using the experimental branch, the following steps:

```
# package the gem
rake package:gem

# install the gem
gem install pkg/passenger-3.1.0.gem

# install nginx via the gem's installer
passenger-install-nginx-module --auto --auto-download --prefix=/opt/nginx
```

results in a failed compilation, because the ext/libev/depcomp script is missing.  This commit adds depcomp to the list of items added to the gem from the ext/libev/ directory.

Best,
Ben 
