### PR TITLE
Fix `rvm_path` detection in RVM mixed mode.

### DIFF
--- a/lib/phusion_passenger/platform_info/ruby.rb
+++ b/lib/phusion_passenger/platform_info/ruby.rb
@@ -164,7 +164,7 @@ module PlatformInfo
 			[ENV['rvm_path'], "~/.rvm", "/usr/local/rvm"].each do |path|
 				next if path.nil?
 				path = File.expand_path(path)
-				script_path = File.join(pathh, 'scripts', 'rvm')
+				script_path = File.join(path, 'scripts', 'rvm')
 				return path if File.directory?(path) && File.exist?(script_path)
 			end
 			# Failure to locate the RVM path is probably caused by the


### PR DESCRIPTION
in RVM mixed mode, rvm and rubies are installed in system and gemsets are installed in user HOME, this was making the code to falsely detect $HOME/.rvm as rvm_path, while it should be /usr/local/rvm.

This change adds checking for $rvm_path/scripts/rvm which is available only in the isntallation path not in the mixed mode in HOME.
