### PR TITLE
Allow soft termination signal to be sent more than once

### DIFF
--- a/lib/phusion_passenger/abstract_request_handler.rb
+++ b/lib/phusion_passenger/abstract_request_handler.rb
@@ -331,14 +331,17 @@ class AbstractRequestHandler
 	# May only be called while the main loop is running. May be called
 	# from any thread.
 	def soft_shutdown
-		@select_timeout = @soft_termination_linger_time
-		@graceful_termination_pipe[1].close rescue nil
-		if @detach_key && @pool_account_username && @pool_account_password
-			client = MessageClient.new(@pool_account_username, @pool_account_password)
-			begin
-				client.detach(@detach_key)
-			ensure
-				client.close
+		unless @soft_terminated
+			@soft_terminated = true
+			@select_timeout = @soft_termination_linger_time
+			@graceful_termination_pipe[1].close rescue nil
+			if @detach_key && @pool_account_username && @pool_account_password
+				client = MessageClient.new(@pool_account_username, @pool_account_password)
+				begin
+					client.detach(@detach_key)
+				ensure
+					client.close
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Currently, if you send the `SOFT_TERMINATION_SIGNAL` more than once to a passenger process it will throw a cryptic error on the 2nd signal. 

This pull request essentially ignores all subsequent soft termination signals and allows the request to finish processing.
- I can't get RSpec working right now for some reason, but I'll try to get it going and write some tests for this.
