### PR TITLE
Fixed bug in installer when extracting tarball with utf-8 character 

### DIFF
--- a/lib/phusion_passenger/standalone/runtime_installer.rb
+++ b/lib/phusion_passenger/standalone/runtime_installer.rb
@@ -1,3 +1,5 @@
+#  encoding: utf-8
+#
 #  Phusion Passenger - http://www.modrails.com/
 #  Copyright (c) 2010 Phusion
 #


### PR DESCRIPTION
This is the stack trace I had when trying to run passenger start in a project right after installing the gem:

```
Downloading Nginx...
# wget -O /tmp/dam5s-passenger-standalone-31737/nginx-1.0.15.tar.gz http://nginx.org/download/nginx-1.0.15.tar.gz
--2012-06-13 09:30:13--  http://nginx.org/download/nginx-1.0.15.tar.gz
Resolving nginx.org... 206.251.255.63
Connecting to nginx.org|206.251.255.63|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 693025 (677K) [application/octet-stream]
Saving to: `/tmp/dam5s-passenger-standalone-31737/nginx-1.0.15.tar.gz'

100%[======================================================================================================================================>] 693,025     1.64M/s   in 0.4s    

2012-06-13 09:30:13 (1.64 MB/s) - `/tmp/dam5s-passenger-standalone-31737/nginx-1.0.15.tar.gz' saved [693025/693025]

Installing Phusion Passenger Standalone...
/Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:261:in `write': "\x8B" on US-ASCII (Encoding::InvalidByteSequenceError)
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:261:in `block (2 levels) in extract_tarball'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:252:in `popen'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:252:in `block in extract_tarball'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:251:in `open'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:251:in `extract_tarball'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:396:in `block in download_and_extract_nginx_sources'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:394:in `chdir'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:394:in `download_and_extract_nginx_sources'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/runtime_installer.rb:133:in `install!'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/abstract_installer.rb:63:in `start'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/start_command.rb:294:in `install_runtime'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/start_command.rb:319:in `ensure_nginx_installed'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/start_command.rb:59:in `run'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:93:in `block in run_command'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:48:in `block in each_command'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:43:in `each'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:43:in `each_command'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:91:in `run_command'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:62:in `run!'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/lib/phusion_passenger/standalone/main.rb:39:in `run!'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/gems/passenger-3.0.12/bin/passenger:32:in `<top (required)>'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/bin/passenger:19:in `load'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/bin/passenger:19:in `<main>'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/dam5s/.rvm/gems/ruby-1.9.3-p125-perf@some-project/bin/ruby_noexec_wrapper:14:in `<main>'
```
