### PR TITLE
Fix simple typo in Watchdog

### DIFF
--- a/ext/common/Watchdog.cpp
+++ b/ext/common/Watchdog.cpp
@@ -800,7 +800,7 @@ setOomScore(const StaticString &score) {
 	FILE *f;
 	OomFileType type;
 	
-	f = openOomAdjFile("r", type);
+	f = openOomAdjFile("w", type);
 	if (f != NULL) {
 		fwrite(score.data(), 1, score.size(), f);
 		fclose(f);


### PR DESCRIPTION
Watchdog.cpp attempts to open "/proc/self/oom_adj" 'r' but then attempts
fwrite.
