### PR TITLE
Backport fix from https://svn.boost.org/trac/boost/ticket/6940

### DIFF
--- a/ext/boost/config/suffix.hpp
+++ b/ext/boost/config/suffix.hpp
@@ -103,6 +103,19 @@
 #endif
 
 //
+// constexpr workarounds
+// 
+#if defined(BOOST_NO_CONSTEXPR)
+#define BOOST_CONSTEXPR
+#define BOOST_CONSTEXPR_OR_CONST const
+#else
+#define BOOST_CONSTEXPR constexpr
+#define BOOST_CONSTEXPR_OR_CONST constexpr
+#endif
+
+#define BOOST_STATIC_CONSTEXPR  static BOOST_CONSTEXPR_OR_CONST
+
+//
 // if there is no __int64 then there is no specialisation
 // for numeric_limits<__int64> either:
 //

--- a/ext/boost/src/pthread/thread.cpp
+++ b/ext/boost/src/pthread/thread.cpp
@@ -24,7 +24,7 @@
 #endif
 #include <cassert>
 
-#include "timeconv.inl"
+#include <boost/src/pthread/timeconv.inl>
 
 namespace boost
 {
@@ -365,7 +365,7 @@ namespace boost
                     cond.timed_wait(lock, xt);
 #   endif
                     xtime cur;
-                    xtime_get(&cur, TIME_UTC);
+                    xtime_get(&cur, TIME_UTC_);
                     if (xtime_cmp(xt, cur) <= 0)
                         return;
                 }
@@ -380,7 +380,7 @@ namespace boost
             BOOST_VERIFY(!pthread_yield());
 #   else
             xtime xt;
-            xtime_get(&xt, TIME_UTC);
+            xtime_get(&xt, TIME_UTC_);
             sleep(xt);
 #   endif
         }

--- a/ext/boost/src/pthread/timeconv.inl
+++ b/ext/boost/src/pthread/timeconv.inl
@@ -20,8 +20,8 @@ const int NANOSECONDS_PER_MICROSECOND = 1000;
 inline void to_time(int milliseconds, boost::xtime& xt)
 {
     int res = 0;
-    res = boost::xtime_get(&xt, boost::TIME_UTC);
-    BOOST_ASSERT(res == boost::TIME_UTC);
+    res = boost::xtime_get(&xt, boost::TIME_UTC_);
+    BOOST_ASSERT(res == boost::TIME_UTC_);
 
     xt.sec += (milliseconds / MILLISECONDS_PER_SECOND);
     xt.nsec += ((milliseconds % MILLISECONDS_PER_SECOND) *
@@ -57,8 +57,8 @@ inline void to_timespec_duration(const boost::xtime& xt, timespec& ts)
 {
     boost::xtime cur;
     int res = 0;
-    res = boost::xtime_get(&cur, boost::TIME_UTC);
-    BOOST_ASSERT(res == boost::TIME_UTC);
+    res = boost::xtime_get(&cur, boost::TIME_UTC_);
+    BOOST_ASSERT(res == boost::TIME_UTC_);
 
     if (boost::xtime_cmp(xt, cur) <= 0)
     {
@@ -88,8 +88,8 @@ inline void to_duration(boost::xtime xt, int& milliseconds)
 {
     boost::xtime cur;
     int res = 0;
-    res = boost::xtime_get(&cur, boost::TIME_UTC);
-    BOOST_ASSERT(res == boost::TIME_UTC);
+    res = boost::xtime_get(&cur, boost::TIME_UTC_);
+    BOOST_ASSERT(res == boost::TIME_UTC_);
 
     if (boost::xtime_cmp(xt, cur) <= 0)
         milliseconds = 0;
@@ -110,8 +110,8 @@ inline void to_microduration(boost::xtime xt, int& microseconds)
 {
     boost::xtime cur;
     int res = 0;
-    res = boost::xtime_get(&cur, boost::TIME_UTC);
-    BOOST_ASSERT(res == boost::TIME_UTC);
+    res = boost::xtime_get(&cur, boost::TIME_UTC_);
+    BOOST_ASSERT(res == boost::TIME_UTC_);
 
     if (boost::xtime_cmp(xt, cur) <= 0)
         microseconds = 0;

--- a/ext/boost/thread/detail/config.hpp
+++ b/ext/boost/thread/detail/config.hpp
@@ -17,7 +17,7 @@
 #  pragma warn -8066 // Unreachable code
 #endif
 
-#include "platform.hpp"
+#include <boost/thread/detail/platform.hpp>
 
 // provided for backwards compatibility, since this
 // macro was used for several releases by mistake.

--- a/ext/boost/thread/locks.hpp
+++ b/ext/boost/thread/locks.hpp
@@ -164,9 +164,9 @@ namespace boost
     struct adopt_lock_t
     {};
     
-    const defer_lock_t defer_lock={};
-    const try_to_lock_t try_to_lock={};
-    const adopt_lock_t adopt_lock={};
+    BOOST_CONSTEXPR_OR_CONST defer_lock_t defer_lock={};
+    BOOST_CONSTEXPR_OR_CONST try_to_lock_t try_to_lock={};
+    BOOST_CONSTEXPR_OR_CONST adopt_lock_t adopt_lock={};
 
     template<typename Mutex>
     class shared_lock;

--- a/ext/boost/thread/xtime.hpp
+++ b/ext/boost/thread/xtime.hpp
@@ -2,7 +2,7 @@
 // William E. Kempf
 // Copyright (C) 2007-8 Anthony Williams
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying 
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_XTIME_WEK070601_HPP
@@ -20,7 +20,7 @@ namespace boost {
 
 enum xtime_clock_types
 {
-    TIME_UTC=1
+    TIME_UTC_=1
 //    TIME_TAI,
 //    TIME_MONOTONIC,
 //    TIME_PROCESS,
@@ -53,14 +53,14 @@ struct xtime
         boost::posix_time::microseconds((nsec+500)/1000);
 #endif
     }
-    
+
 };
 
 inline xtime get_xtime(boost::system_time const& abs_time)
 {
     xtime res;
     boost::posix_time::time_duration const time_since_epoch=abs_time-boost::posix_time::from_time_t(0);
-            
+
     res.sec=static_cast<xtime::xtime_sec_t>(time_since_epoch.total_seconds());
     res.nsec=static_cast<xtime::xtime_nsec_t>(time_since_epoch.fractional_seconds()*(1000000000/time_since_epoch.ticks_per_second()));
     return res;
@@ -68,7 +68,7 @@ inline xtime get_xtime(boost::system_time const& abs_time)
 
 inline int xtime_get(struct xtime* xtp, int clock_type)
 {
-    if (clock_type == TIME_UTC)
+    if (clock_type == TIME_UTC_)
     {
         *xtp=get_xtime(get_system_time());
         return clock_type;
@@ -81,7 +81,7 @@ inline int xtime_cmp(const xtime& xt1, const xtime& xt2)
 {
     if (xt1.sec == xt2.sec)
         return (int)(xt1.nsec - xt2.nsec);
-    else 
+    else
         return (xt1.sec > xt2.sec) ? 1 : -1;
 }
 


### PR DESCRIPTION
This allows passenger to build on Fedora 18/19.
