### PR TITLE
Fix SunOS by removing a duplicate CFLAGS declaration

### DIFF
--- a/lib/phusion_passenger/platform_info/compiler.rb
+++ b/lib/phusion_passenger/platform_info/compiler.rb
@@ -150,7 +150,6 @@ module PlatformInfo
 				flags << '-D_XOPEN_SOURCE=500 -D_XPG4_2 -D__EXTENSIONS__ -D__SOLARIS__ -D_FILE_OFFSET_BITS=64'
 				flags << '-D__SOLARIS9__ -DBOOST__STDC_CONSTANT_MACROS_DEFINED' if RUBY_PLATFORM =~ /solaris2.9/
 			end
-			flags << '-D_XOPEN_SOURCE=500 -D_XPG4_2 -D__EXTENSIONS__ -D__SOLARIS__ -D_FILE_OFFSET_BITS=64'
 			flags << '-DBOOST_HAS_STDINT_H' unless RUBY_PLATFORM =~ /solaris2.9/
 			flags << '-mcpu=ultrasparc' if RUBY_PLATFORM =~ /sparc/
 		elsif RUBY_PLATFORM =~ /openbsd/


### PR DESCRIPTION
Hi guys,

please merge this easy one to _finally_ fix SunOS build with a recent GCC version. Currently CFLAGS are declared twice, and the second occurrence is still breaking GCC>=4.6 on SunOS.

Regards,

Filip
