### PR TITLE
Fixes warning about unused variables

### DIFF
--- a/ext/nginx/Configuration.c
+++ b/ext/nginx/Configuration.c
@@ -110,8 +110,6 @@ char *
 passenger_init_main_conf(ngx_conf_t *cf, void *conf_pointer)
 {
     passenger_main_conf_t *conf;
-    u_char                 filename[NGX_MAX_PATH], *last;
-    ngx_str_t              str;
     struct passwd         *user_entry;
     struct group          *group_entry;
     char buf[128];


### PR DESCRIPTION
A couple of unused variables cause the build to error out with `-Wall -Wextra`.
