### PR TITLE
passenger-install-apache2-module doesn't work on ruby 2.0

### DIFF
--- a/build/gempackagetask.rb
+++ b/build/gempackagetask.rb
@@ -9,7 +9,12 @@ require 'rubygems'
 require 'rake'
 require 'build/packagetask'
 require 'rubygems/user_interaction'
-require 'rubygems/builder'
+
+if /^2\./ =~ RUBY_VERSION
+  require 'rubygems/package'
+else
+  require 'rubygems/builder'
+end
 
 module Rake
 
@@ -79,7 +84,11 @@ module Rake
       task 'package:gem' => ["#{package_dir}/#{gem_file}"]
       file "#{package_dir}/#{gem_file}" => [package_dir] + @gem_spec.files do
         when_writing("Creating GEM") {
-          Gem::Builder.new(gem_spec).build
+          if /^2\./ =~ RUBY_VERSION
+            Gem::Package.build(gem_spec)
+          else
+            Gem::Builder.new(gem_spec).build
+          end
           verbose(true) {
             mv gem_file, "#{package_dir}/#{gem_file}"
           }


### PR DESCRIPTION
Now passenger-install-apache2-module failed on ruby 2.0

---

Checking for required software...
- GNU C++ compiler... found at /usr/bin/g++
- Curl development headers with SSL support... found
- OpenSSL development headers... found
- Zlib development headers... found
- Ruby development headers... found
- OpenSSL support for Ruby... found
- RubyGems... found
- Rake... found at /opt/ruby/2.0/bin/rake
- rack... found
- Apache 2... found at /usr/sbin/apache2
- Apache 2 development headers... found at /usr/bin/apxs2
- Apache Portable Runtime (APR) development headers... found at /usr/bin/apr-1-config
- Apache Portable Runtime Utility (APU) development headers... found at /usr/bin/apu-1-config

---

Compiling and installing Apache 2 module...
(Omitted)

rake aborted!
cannot load such file -- rubygems/builder

(See full trace by running task with --trace)

---

It looks like something went wrong

This patch will fix this issue.
So, passenger will well done on ruby 1.9 and 2.0.
