### PR TITLE
Fixes RVM Wrapper out of date.

### DIFF
--- a/lib/phusion_passenger/platform_info/ruby.rb
+++ b/lib/phusion_passenger/platform_info/ruby.rb
@@ -236,7 +236,9 @@ module PlatformInfo
 			
 			# $GEM_HOME usually contains the gem set name.
 			if GEM_HOME && GEM_HOME.include?("rvm/gems/")
-				return File.basename(GEM_HOME)
+				# Matches 'ruby-1.9.3-anythinguptoatsign', '1.9.1', 'ruby-1.8.7' etc.
+                                matches =GEM_HOME.match(/((ruby[^\/])?\d\D\d\D\d[^@\/\\]*)/)
+                                return matches[0] if not matches[0].nil?
 			end
 			
 			# User somehow managed to nuke $GEM_HOME. Extract info


### PR DESCRIPTION
Ruby 1.9.2/1.9.3 gems are binary compatible with 1.9.1 so gems are often stored in a 1.9.1 directory. Passenger erroneously looked in the 'wrappers/1.9.1/ruby" folder, causing the 'RVM wrapper error', when 1.9.1 wasn't even installed.

Fixes issues 828 and 771 for me.

The wrappers have never been out of date!
