### PR TITLE
Skip development header checks in jruby environment

### DIFF
--- a/bin/passenger-install-apache2-module
+++ b/bin/passenger-install-apache2-module
@@ -74,6 +74,7 @@ class Installer < PhusionPassenger::AbstractInstaller
 			ids << 'apr-dev'
 			ids << 'apu-dev'
 		end
+		ids.delete('ruby-dev') if(RUBY_PLATFORM == "java")
 		return [specs, ids]
 	end
 	

--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -56,6 +56,7 @@ class Installer < PhusionPassenger::AbstractInstaller
 			'openssl-dev',
 			'zlib-dev'
 		]
+		ids.delete('ruby-dev') if(RUBY_PLATFORM == "java")
 		return [specs, ids]
 	end
 	


### PR DESCRIPTION
This commit skips the development header checks when installing a server in a jruby environment.
