### PR TITLE
fix a spelling mistake in the documentation

### DIFF
--- a/doc/Users guide Apache.txt
+++ b/doc/Users guide Apache.txt
@@ -994,7 +994,7 @@ The maximum number of <<application_process,application processes>> that may
 simultaneously exist. A larger number results in higher memory usage,
 but improves the ability to handle concurrent HTTP requests.
 
-The optimal value depends on your system's hardware and your workload. You can learn more at the Phusion article link:http://blog.phusion.nl/2013/03/12/tuning-phusion-passengers-concurrency-settings/[Tuning Phusion Passenger's conurrency settings].
+The optimal value depends on your system's hardware and your workload. You can learn more at the Phusion article link:http://blog.phusion.nl/2013/03/12/tuning-phusion-passengers-concurrency-settings/[Tuning Phusion Passenger's concurrency settings].
 
 If you find that your server is running out of memory then you should lower this value.
 

--- a/doc/Users guide Nginx.txt
+++ b/doc/Users guide Nginx.txt
@@ -981,7 +981,7 @@ The maximum number of <<application_process,application processes>> that may
 simultanously exist. A larger number results in higher memory usage,
 but improves the ability to handle concurrent HTTP requests.
 
-The optimal value depends on your system's hardware and your workload. You can learn more at the Phusion article link:http://blog.phusion.nl/2013/03/12/tuning-phusion-passengers-concurrency-settings/[Tuning Phusion Passenger's conurrency settings].
+The optimal value depends on your system's hardware and your workload. You can learn more at the Phusion article link:http://blog.phusion.nl/2013/03/12/tuning-phusion-passengers-concurrency-settings/[Tuning Phusion Passenger's concurrency settings].
 
 If you find that your server is running out of memory then you should lower this value.
 


### PR DESCRIPTION
The current docs say conurrency when they mean concurrency
