### PR TITLE
Allow turning off friendly error pages when running standalone

### DIFF
--- a/lib/phusion_passenger/standalone/command.rb
+++ b/lib/phusion_passenger/standalone/command.rb
@@ -35,7 +35,8 @@ class Command
 		:max_pool_size => 6,
 		:min_instances => 1,
 		:spawn_method  => Kernel.respond_to?(:fork) ? 'smart' : 'direct',
-		:nginx_version => PREFERRED_NGINX_VERSION
+		:nginx_version => PREFERRED_NGINX_VERSION,
+		:friendly_error_pages => true
 	}.freeze
 	
 	include Utils

--- a/lib/phusion_passenger/standalone/start_command.rb
+++ b/lib/phusion_passenger/standalone/start_command.rb
@@ -156,6 +156,10 @@ private
 				wrap_desc("Enable deployment error resistance (Enterprise only)")) do
 				@options[:resist_deployment_errors] = true
 			end
+			opts.on("--no-friendly-error-pages",
+				wrap_desc("Disable passenger_friendly_error_pages")) do
+				@options[:friendly_error_pages] = false
+			end
 			opts.on("--union-station-gateway HOST:PORT", String,
 				wrap_desc("Specify Union Station Gateway host and port")) do |value|
 				host, port = value.split(":", 2)

--- a/resources/templates/standalone/config.erb
+++ b/resources/templates/standalone/config.erb
@@ -29,7 +29,9 @@ http {
     <% if debugging? %>passenger_log_level 2;<% end %>
     <% if @options[:rolling_restarts] %>passenger_rolling_restarts on;<% end %>
     <% if @options[:resist_deployment_errors] %>passenger_resist_deployment_errors on;<% end %>
-    
+
+    <% unless @options[:friendly_error_pages] %>passenger_friendly_error_pages off;<% end %>
+
     <% if @options[:union_station_gateway_address] %>
         union_station_gateway_address <%= @options[:union_station_gateway_address] %>;
         union_station_gateway_port <%= @options[:union_station_gateway_port] %>;


### PR DESCRIPTION
I'm not sure if I missed something in the docs, but I couldn't find a way to start passenger standalone with the friendly error pages turned off. I added a command line option `--no-friendly-error-pages` to allow you to make sure the friendly error pages don't get served in production. The default is still to serve them and they're only off if the new option is passed.

If there is a better way of turning them off in production I'd be curious to know what I missed.

Thanks!
