### PR TITLE
Increased Nginx types_hash_max_size

### DIFF
--- a/resources/templates/standalone/config.erb
+++ b/resources/templates/standalone/config.erb
@@ -37,6 +37,7 @@ http {
     <% end %>
     
     default_type application/octet-stream;
+    types_hash_max_size 2048;
     client_max_body_size 1024m;
     access_log off;
     keepalive_timeout 60;


### PR DESCRIPTION
In our current setup (passenger 4.0.2, ruby 1.9.3-p429, 2.0.0-p0 and
2.0.0-p195) the built in Nginx would not start, giving the following
error:

```
2013/05/24 12:08:38 [emerg] 31429#0: could not build the types_hash, you
should increase either types_hash_max_size: 1024 or types_hash_bucket_size: 32
```

This commit does just that, increase the types_hash_max_size to 2048,
which makes Passenger boot again.
