### PR TITLE
AArch64 Porting (SYS_fork)

### DIFF
--- a/ext/common/Utils.cpp
+++ b/ext/common/Utils.cpp
@@ -987,7 +987,11 @@ runShellCommand(const StaticString &command) {
 pid_t
 asyncFork() {
 	#if defined(__linux__)
-		return (pid_t) syscall(SYS_fork);
+		#if defined(SYS_fork)
+			return (pid_t) syscall(SYS_fork);
+		#else
+			return syscall(SYS_clone, SIGCHLD, 0, 0, 0, 0);
+		#endif
 	#elif defined(__APPLE__)
 		return __fork();
 	#else


### PR DESCRIPTION
Linux on AArch64 is a new platform and hence
does not provide support for the old compatibility
syscalls like e.g. SYS_fork. It offers howver
SYS_clone (which iswhat SYS_fork is being mapped to
on all other platforms anyway).
