### PR TITLE
'passenger enabled on' required under location block on using different passenger_ruby

### DIFF
--- a/doc/Users guide Nginx.txt
+++ b/doc/Users guide Nginx.txt
@@ -510,6 +510,7 @@ http {
         # The web app under www.bar.com/blog will use JRuby 1.7.1
         passenger_base_uri /blog;
         location /blog {
+            passenger_enabled on;
             passenger_ruby /usr/local/rvm/wrappers/jruby-1.7.1/ruby;
         }
     }


### PR DESCRIPTION
The example given for passenger_ruby won't work and will return 403 forbidden error from nginx. It works with 'passenger_enabled on' inside location block. I am not sure if it's a bug or a documentation error though.
