### PR TITLE
dynamic_cast<> with pointers instead of reference and compare against NU...

### DIFF
--- a/ext/common/ApplicationPool2/Implementation.cpp
+++ b/ext/common/ApplicationPool2/Implementation.cpp
@@ -42,22 +42,11 @@ using namespace std;
 using namespace boost;
 using namespace oxt;
 
-
-template<typename T>
-static bool
-exceptionIsInstanceOf(const tracable_exception &e) {
-	try {
-		(void) dynamic_cast<T>(e);
-		return true;
-	} catch (const bad_cast &) {
-		return false;
-	}
-}
-
 #define TRY_COPY_EXCEPTION(klass) \
 	do { \
-		if (exceptionIsInstanceOf<const klass &>(e)) { \
-			return make_shared<klass>( (const klass &) e ); \
+		const klass * ep = dynamic_cast<const klass *>(&e); \
+		if (ep != NULL) { \
+			return make_shared<klass>(*ep); \
 		} \
 	} while (false)
 
@@ -96,8 +85,9 @@ copyException(const tracable_exception &e) {
 
 #define TRY_RETHROW_EXCEPTION(klass) \
 	do { \
-		if (exceptionIsInstanceOf<const klass &>(*e)) { \
-			throw klass((const klass &) *e); \
+		const klass * ep = dynamic_cast<const klass *>(&*e); \
+		if (ep != NULL) { \
+			throw klass(*ep); \
 		} \
 	} while (false)
 

--- a/ext/common/UnionStation.h
+++ b/ext/common/UnionStation.h
@@ -269,15 +269,16 @@ private:
 		switch (exceptionHandlingMode) {
 		case THROW:
 			throw e;
-		case PRINT:
-			try {
-				const tracable_exception &te =
-					dynamic_cast<const tracable_exception &>(e);
-				P_WARN(te.what() << "\n" << te.backtrace());
-			} catch (const bad_cast &) {
-				P_WARN(e.what());
+		case PRINT: {
+				const tracable_exception *te =
+					dynamic_cast<const tracable_exception *>(&e);
+				if (te != NULL) {
+					P_WARN(te->what() << "\n" << te->backtrace());
+				} else {
+					P_WARN(e.what());
+				}
+				break;
 			}
-			break;
 		default:
 			break;
 		}
@@ -587,12 +588,7 @@ private:
 
 	template<typename T>
 	static bool instanceof(const std::exception &e) {
-		try {
-			(void) dynamic_cast<const T &>(e);
-			return true;
-		} catch (const bad_cast &) {
-			return false;
-		}
+		return dynamic_cast<const T *>(&e) != NULL;
 	}
 	
 	ConnectionPtr createNewConnection() {


### PR DESCRIPTION
Rework the down cast to use dynami_cast<> on pointers + comparison against NULL instead of dynamic_cast on references + std::bad_cast catch.

This is faster and safer: 
1 comparison 
VS 
1 comparison and maybe (1 throw and 1 catch)
