### PR TITLE
Protection against blank headers (makes passenger raise and crash)

### DIFF
--- a/lib/phusion_passenger/rack/thread_handler_extension.rb
+++ b/lib/phusion_passenger/rack/thread_handler_extension.rb
@@ -106,6 +106,7 @@ module ThreadHandlerExtension
 						# iteration as an optimization.
 						next
 					end
+					values ||= [''] #Protect agains blank headers
 					values.each do |value|
 						headers_output << key
 						headers_output << NAME_VALUE_SEPARATOR


### PR DESCRIPTION
With this patch, passenger will return an empty header instead of crashing.
