### PR TITLE
fix bug where Date header was incorrectly formatted as week-based year

### DIFF
--- a/ext/common/agents/HelperAgent/RequestHandler.h
+++ b/ext/common/agents/HelperAgent/RequestHandler.h
@@ -1071,7 +1071,7 @@ private:
 
 			pos = appendData(pos, end, "Date: ");
 			gmtime_r(&the_time, &the_tm);
-			pos += strftime(pos, end - pos, "%a, %d %b %G %H:%M:%S %Z", &the_tm);
+			pos += strftime(pos, end - pos, "%a, %d %b %Y %H:%M:%S %Z", &the_tm);
 			pos = appendData(pos, end, "\r\n");
 			headerData.append(dateStr, pos - dateStr);
 		}


### PR DESCRIPTION
Passenger sometimes gets the date wrong when appending the http Date header to responses.  This happens when the week-based year differs from the calendar year.  It happens because it uses `%G` to print the year when it should be using `%Y` (see this commit:  https://github.com/phusion/passenger/commit/15ed1d4aef7aba8f635ce68c559583d61a3b267d).

Given the time `2013-12-30 18:12:43 UTC`, the date header using the week-based year is printed as:

`Mon, 30 Dec 2014 18:12:43 UTC`

Whereas the header using the calendar-based year would be printed as:

`Mon, 30 Dec 2013 18:12:43 UTC`

Notice that the week-based year is December of 2014.  This causes cookies to appear invalid on any browser that uses the date header to calculate cookie expiration (such as Chrome).  We discovered this today while debugging a problem where no users could log into our Rails app in Chrome or Firefox.

I'm not good enough at C++ yet to quickly write a unit test for this, but I wanted to submit this immediately because I imagine it is affecting a number of rails sites.
