### PR TITLE
Apply a fix similar to 6b16991 'ps -p', no space before dash-p option ar...

### DIFF
--- a/ext/common/Utils/ProcessMetricsCollector.h
+++ b/ext/common/Utils/ProcessMetricsCollector.h
@@ -450,14 +450,16 @@ public:
 		if (pidsArg[pidsArg.size() - 1] == ',') {
 			pidsArg.resize(pidsArg.size() - 1);
 		}
+
+		string fmtArg = "-o";
+		#if defined(sun) || defined(__sun)
+			fmtArg.append("pid,ppid,pcpu,rss,vsz,pgid,uid,args");
+		#else
+			fmtArg.append("pid,ppid,%cpu,rss,vsize,pgid,uid,command");
+		#endif
 		
 		const char *command[] = {
-			"ps", "-o",
-			#if defined(sun) || defined(__sun)
-				"pid,ppid,pcpu,rss,vsz,pgid,uid,args",
-			#else
-				"pid,ppid,%cpu,rss,vsize,pgid,uid,command",
-			#endif
+			"ps", fmtArg.c_str(),
 			#ifdef PS_SUPPORTS_MULTIPLE_PIDS
 				pidsArg.c_str(),
 			#endif
@@ -469,6 +471,7 @@ public:
 			psOutput = runCommandAndCaptureOutput(command);
 		}
 		pidsArg.resize(0);
+		fmtArg.resize(0);
 		ProcessMetricMap result = parsePsOutput<Collection, ConstIterator>(psOutput, pids);
 		psOutput.resize(0);
 		if (canMeasureRealMemory) {


### PR DESCRIPTION
...gs; also needed for the '-o' option of ps.  Tested on Ubuntu 11.04 vm.  Without this fix, the passenger logfile grows out of control.
