### PR TITLE
Fixed possible hang when reload or reopen log files

### DIFF
--- a/ext/common/Utils.cpp
+++ b/ext/common/Utils.cpp
@@ -888,14 +888,6 @@ getSignalName(int sig) {
 
 void
 resetSignalHandlersAndMask() {
-	sigset_t signal_set;
-	int ret;
-	
-	sigemptyset(&signal_set);
-	do {
-		ret = sigprocmask(SIG_SETMASK, &signal_set, NULL);
-	} while (ret == -1 && errno == EINTR);
-	
 	struct sigaction action;
 	action.sa_handler = SIG_DFL;
 	action.sa_flags   = SA_RESTART;
@@ -926,6 +918,14 @@ resetSignalHandlersAndMask() {
 	#endif
 	sigaction(SIGUSR1, &action, NULL);
 	sigaction(SIGUSR2, &action, NULL);
+
+	sigset_t signal_set;
+	int ret;
+	
+	sigemptyset(&signal_set);
+	do {
+		ret = sigprocmask(SIG_SETMASK, &signal_set, NULL);
+	} while (ret == -1 && errno == EINTR);
 }
 
 void


### PR DESCRIPTION
When reload nginx, nginx master call Passenger::AgentsStarter::start () , it maybe hung at read().

``` shell
#0  0x00000037e480d590 in __read_nocancel () from /lib64/libpthread.so.0
#1  0x00000000004b1154 in oxt::syscalls::read ()
#2  0x00000000004798d4 in Passenger::readExact ()
#3  0x00000000004a39bd in Passenger::readArrayMessage<std::vector<std::string, std::allocator<std::string> > > ()
#4  0x00000000004aa6e5 in Passenger::AgentsStarter::start ()
#5  0x00000000004805a2 in agents_starter_start ()
#6  0x000000000046cd9d in init_module ()
#7  0x00000000004172dd in ngx_init_cycle ()
#8  0x0000000000425f72 in ngx_master_process_cycle ()
#9  0x000000000040a91d in main ()
```

This happened when `nginx master` forked a child process who will exec() `PassengerWatchdog`. When the child call `getHighestFileDescriptor()`, it would fork a process. When this process exited, the `PassengerWatchdog` would get a blocked `SIGCHLD` signal. When it call `sigprocmask`  in `resetSignalHandlersAndMask()`, it would process the blocked `SIGCHLD` signal. Now the signal handler is `ngx_signal_handler()`. It would write some error log. If the fd of error log was 3, it would send some incorrect content to the master process. So the master would hung.

The strace of `PassengerWatchdog` process is like this:

``` shell
23283 close(5 <unfinished ...>
23283 <... close resumed> )             = 0
23283 close(4 <unfinished ...>
23283 <... close resumed> )             = 0
23283 rt_sigprocmask(SIG_SETMASK, [],  <unfinished ...>
23283 <... rt_sigprocmask resumed> NULL, 8) = 0
23283 --- SIGCHLD (Child exited) @ 0 (0) ---
23283 write(3, "2014/03/04 15:15:55 [notice] 156"..., 67 <unfinished ...>
23283 <... write resumed> )             = 67
23283 wait4(-1,  <unfinished ...>
23283 <... wait4 resumed> 0x7fffe9946a6c, WNOHANG, NULL) = -1 ECHILD (No child processes)
23283 rt_sigreturn(0xffffffffffffffff <unfinished ...>
23283 <... rt_sigreturn resumed> )      = 0
23283 rt_sigaction(SIGHUP, {SIG_DFL, [], SA_RESTORER|SA_RESTART, 0x37e480e7c0},  <unfinished ...>
23283 <... rt_sigaction resumed> NULL, 8) = 0
23283 rt_sigaction(SIGINT, {SIG_DFL, [], SA_RESTORER|SA_RESTART, 0x37e480e7c0},  <unfinished ...>
23283 <... rt_sigaction resumed> NULL, 8) = 0
```
