### PR TITLE
Minor documentation fix in Standalone Users Guide

### DIFF
--- a/doc/Users guide Standalone.txt
+++ b/doc/Users guide Standalone.txt
@@ -130,7 +130,7 @@ Every time you start Standalone, you must pass the `--nginx-config-template` par
 
 [source,sh]
 ------------------------------------------
-passenger start --nginx-config-template nginx.config.erb
+passenger start --nginx-config-template nginx.conf.erb
 ------------------------------------------
 
 Alternatively, if you don't want to pass this parameter every time, you can also set the `nginx_config_template` option in <<config_file,passenger-standalone.json>>.


### PR DESCRIPTION
Let's use the same filename in both shell examples for --nginx-config-template. I was just copy-and-pasting those commands and found myself with a _File not found_ error.
