### PR TITLE
Check for false result after the call of run_compiler

### DIFF
--- a/lib/phusion_passenger/platform_info/compiler.rb
+++ b/lib/phusion_passenger/platform_info/compiler.rb
@@ -268,7 +268,7 @@ public
 				"-c '#{filename}' -o '#{filename}.o'",
 				flags)
 			result = run_compiler(description, command, filename, source, true)
-			return result[:result] && result[:output] !~ /unknown warning option/i
+			return result && result[:result] && result[:output] !~ /unknown warning option/i
 		end
 	end
 	


### PR DESCRIPTION
I'm not a ruby guy, but this modification prevents rake abortion with "undefined method `[]' for false:FalseClass" when result is false (which is a possible return value for the run_compiler function).

I don't now if it respects the wanted logic of the code flow, but this patch allowed me to run "passenger-install-apache2-module" without trouble.
