### PR TITLE
Added MIME type for open web app manifests

### DIFF
--- a/resources/mime.types
+++ b/resources/mime.types
@@ -53,6 +53,7 @@ types {
     application/x-shockwave-flash         swf;
     application/x-stuffit                 sit;
     application/x-tcl                     tcl tk;
+    application/x-web-app-manifest+json   webapp;
     application/x-x509-ca-cert            der pem crt;
     application/x-xpinstall               xpi;
     application/zip                       zip;


### PR DESCRIPTION
As a Phusion Passenger user who deploys to Heroku, I have struggled to serve certain static assets because editing the Nginx configuration file on Heroku during slug compilation to support the additional MIME types is a huge pain. Adding the MIME types to Passenger itself seems like a better solution overall than resorting to elaborate erb-based templates that may or may not work from version to version.

This pull request adds support for [open web app manifest](https://developer.mozilla.org/en-US/Apps/Build/Manifest) files.
