### PR TITLE
Add post argument to passenger_ignore_headers directive

### DIFF
--- a/ext/nginx/ConfigurationCommands.c
+++ b/ext/nginx/ConfigurationCommands.c
@@ -266,7 +266,7 @@
 	ngx_conf_set_bitmask_slot,
 	NGX_HTTP_LOC_CONF_OFFSET,
 	offsetof(passenger_loc_conf_t, upstream_config.ignore_headers),
-	NULL
+	&ngx_http_upstream_ignore_headers_masks
 },
 
 {

--- a/ext/nginx/ConfigurationCommands.c.erb
+++ b/ext/nginx/ConfigurationCommands.c.erb
@@ -123,6 +123,11 @@ def struct_field_for(option)
 		return "offsetof(#{struct_type_for(option)}, #{field})"
 	end
 end
+
+def post_for(option)
+	return option[:post] if option[:post]
+	return "NULL"
+end
 %>
 
 <% for option in LOCATION_CONFIGURATION_OPTIONS %>
@@ -133,6 +138,6 @@ end
 	<%= setter_function_for(option) %>,
 	<%= struct_for(option) %>,
 	<%= struct_field_for(option) %>,
-	NULL
+	<%= post_for(option) %>
 },
 <% end %>

--- a/lib/phusion_passenger/nginx/config_options.rb
+++ b/lib/phusion_passenger/nginx/config_options.rb
@@ -66,6 +66,7 @@
 #            a dot (.e.g `upstream_config.pass_headers`) then the structure field will
 #            also not be auto-generated, because it is assumed to belong to an existing
 #            structure field.
+#  * post - The extra information needed by function for post-processing.
 #  * header - The name of the corresponding CGI header. By default CGI header
 #             generation code is automatically generated, using the configuration
 #             option's name in uppercase as the CGI header name.
@@ -193,7 +194,8 @@ LOCATION_CONFIGURATION_OPTIONS = [
 		:name     => 'passenger_ignore_headers',
 		:take     => 'NGX_CONF_1MORE',
 		:function => 'ngx_conf_set_bitmask_slot',
-		:field    => 'upstream_config.ignore_headers'
+		:field    => 'upstream_config.ignore_headers',
+		:post     => '&ngx_http_upstream_ignore_headers_masks'
 	},
 	{
 		:name   => 'passenger_set_cgi_param',


### PR DESCRIPTION
No `post` argument specified in `passenger_ignore_headers` directive's `ngx_command_t` structure.
Fixed it.
