### PR TITLE
Enhance `mkstemps` detection on linux with glibc version sniffing.

### DIFF
--- a/ext/common/ApplicationPool2/Implementation.cpp
+++ b/ext/common/ApplicationPool2/Implementation.cpp
@@ -187,7 +187,7 @@ void processAndLogNewSpawnException(SpawnException &e, const Options &options,
 		UPDATE_TRACE_POINT();
 		errorPage = renderer.renderWithDetails(appMessage, options, &e);
 
-		#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+		#if (defined(__linux__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11))) || defined(__APPLE__) || defined(__FreeBSD__)
 			snprintf(filename, PATH_MAX, "%s/passenger-error-XXXXXX.html",
 				getSystemTempDir());
 			fd = mkstemps(filename, sizeof(".html") - 1);


### PR DESCRIPTION
According to https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=63be362731c0a3c7021485284a7abbefb86ab228;hb=HEAD , `mkstemps` was added to glibc in version 2.11 and as such may not be available on all glibc-based platforms. RHEL5 is still based on glibc 2.5, for instance.
