### PR TITLE
Add a few common, compressable types to gzip_types

### DIFF
--- a/resources/templates/standalone/config.erb
+++ b/resources/templates/standalone/config.erb
@@ -85,7 +85,9 @@ http {
     gzip_min_length 150;
     gzip_proxied any;
     gzip_types text/plain text/css text/json text/javascript \
-        application/javascript application/x-javascript application/json;
+        application/javascript application/x-javascript application/json \
+        application/rss+xml application/vnd.ms-fontobject application/x-font-ttf \
+        application/xml font/opentype image/svg+xml text/xml;
     
     <% if @apps.size > 1 %>
     # Default server entry.


### PR DESCRIPTION
After switching to Passenger, we found that YSlow and Google PageSpeed were warning about lack of compression on our font and SVG files. This change adds the following types to the `gzip_types` configuration parameter in the default NginX config:
- application/rss+xml
- application/vnd.ms-fontobject
- application/x-font-ttf
- application/xml
- font/opentype
- image/svg+xml
- text/xml
