### PR TITLE
pushed opensuse patch rubygem-passenger-4.0.14_missing_includes.patch

### DIFF
--- a/ext/common/Utils/MD5.h
+++ b/ext/common/Utils/MD5.h
@@ -55,9 +55,8 @@
     #include <string>
     #include <StaticString.h>
     namespace Passenger {
-#else
-    #include <stdint.h>
 #endif
+#include <stdint.h>
 
 /*
  * This package supports both compile-time and run-time determination of CPU


### PR DESCRIPTION
This patch fixed a build problem for us.