### PR TITLE
Catch nil.split in parse_http_request

### DIFF
--- a/lib/phusion_passenger/request_handler/thread_handler.rb
+++ b/lib/phusion_passenger/request_handler/thread_handler.rb
@@ -246,6 +246,11 @@ private
 				request_method = $1
 				request_uri    = $2
 				protocol       = $3
+				if request_method.nil?
+					warn("*** Passenger RequestHandler warning: " <<
+						"Invalid HTTP request.")
+					return
+				end
 				path_info, query_string    = request_uri.split("?", 2)
 				headers[REQUEST_METHOD]    = request_method
 				headers["REQUEST_URI"]     = request_uri


### PR DESCRIPTION
An invalid HTTP request results in the following trace.
To prevent the thread from dying - let's catch corner case and return a warning.

This fixes phusion/passenger#1311