### PR TITLE
Fix a bug in crash reporting, and a thanks

### DIFF
--- a/ext/common/agents/Base.cpp
+++ b/ext/common/agents/Base.cpp
@@ -96,7 +96,7 @@ static bool _feedbackFdAvailable = false;
 static const char digits[] = {
 	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
 };
-static const char hex_chars[] = "01234567890abcdef";
+static const char hex_chars[] = "0123456789abcdef";
 
 static bool shouldDumpWithCrashWatch = true;
 static bool beepOnAbort = false;


### PR DESCRIPTION
Hi,

First off, thanks for Passenger; I don't actually use it, but I recently extracted out and finished polishing a copy of your small crash reporting library, under `ext/common/agents/Base.cpp`, based on an old Reddit comment by @FooBarWidget: http://www.reddit.com/r/programming/comments/13vmik/redis_crashes_a_small_rant_about_software/c783lzx (fun fact: I am the `aseipp` below who replied; I finally got around to finishing this. My latency is quite high).

This code is available in https://github.com/thoughtpolice/libfault, and has most of the same features (I need to fix a few things). It obviously has derived a lot of code from Passenger, just cleaned up to be standalone C instead. There is still more work to do. I imagine you probably do not want to switch to my copy (I see no point in that personally), but I figured you might like to know the code has become a bit more generally useful.

In the process of this I discovered a bug: `hex_chars` in the agent fault handling code contains 0 twice. This leads to addresses being displayed incorrectly; for example, in `libfault` tests on x86_64, a simple `*NULL = 0;` normally leads to a crash where `RCX = 0xFFFFFFFFFFFFFFFF`, which can be verified if you have the handler send `SIGSTOP` and attach a debugger, or just run it under GDB. However, with `0` being included twice, this address comes out to `0xEEEEEEEEEEEEEEEE`, which is wrong and pretty misleading. It gets worse when you dump registers and memory maps, since `RIP` then no longer matches up with what you expect in `/proc/self/maps`, either, etc etc.

This PR removes the extraneous zero.

BTW: I find displaying addresses/registers without the leading zeros normally a bit confusing and it makes it harder to do things like align text in the output properly. In `libfault` I changed this so every hex string is properly formatted with the right amount of leading zeros. I am not sure if you want to adopt this, but the code is [here](https://github.com/thoughtpolice/libfault/blob/master/lib/libfault.c#L330) (with no template polymorphism) and a straightforward addition to your own code. The `libfault` README contains an example of displaying addresses etc with extra information.
