### PR TITLE
Fix File descriptor leak related to GH-1324.

### DIFF
--- a/ext/common/ApplicationPool2/Implementation.cpp
+++ b/ext/common/ApplicationPool2/Implementation.cpp
@@ -184,7 +184,6 @@ void processAndLogNewSpawnException(SpawnException &e, const Options &options,
 
 	try {
 		int fd = -1;
-		FdGuard guard(fd, true);
 		string errorPage;
 
 		UPDATE_TRACE_POINT();
@@ -199,6 +198,7 @@ void processAndLogNewSpawnException(SpawnException &e, const Options &options,
 				getSystemTempDir());
 			fd = mkstemp(filename);
 		#endif
+		FdGuard guard(fd, true);
 		if (fd == -1) {
 			int e = errno;
 			throw SystemException("Cannot generate a temporary filename",


### PR DESCRIPTION
Following my comment on the code, here is the fix for issue #1324 !

Thanks @FooBarWidget for your work !
# Before fix

```
> ab -n 1000 -c 10 http://localhost &
> # Waiting a couple of seconds
> lsof | grep -i passenger-error | wc -l
495
```
# After fix

```
> ab -n 1000 -c 10 http://localhost &
> # Waiting a couple of seconds
> lsof | grep -i passenger-error | wc -l
0
```
