### PR TITLE
Remove redundant deleting of SIGKILL from trappable signals on JRuby

### DIFF
--- a/lib/phusion_passenger/ruby_core_enhancements.rb
+++ b/lib/phusion_passenger/ruby_core_enhancements.rb
@@ -100,7 +100,6 @@ module Signal
 			result.delete("QUIT")
 			result.delete("ILL")
 			result.delete("FPE")
-			result.delete("KILL")
 			result.delete("SEGV")
 			result.delete("USR1")
 			result.delete("IOT")


### PR DESCRIPTION
This check is done unconditionally later in the method.