### PR TITLE
print full ruby path when prespawn fails

### DIFF
--- a/ext/common/Utils.cpp
+++ b/ext/common/Utils.cpp
@@ -812,7 +812,8 @@ prestartWebApps(const ResourceLocator &locator, const string &ruby,
 				it->c_str(),
 				(char *) 0);
 			e = errno;
-			fprintf(stderr, "Cannot execute '%s %s': %s (%d)\n",
+			fprintf(stderr, "Cannot execute '%s %s %s': %s (%d)\n",
+				ruby.c_str(),
 				prespawnScript.c_str(), it->c_str(),
 				strerror(e), e);
 			fflush(stderr);


### PR DESCRIPTION
This would make it a bit easier to debug prespawn problems.