### PR TITLE
Fix integer overflow when setting maxIdleTime

### DIFF
--- a/ext/common/agents/HelperAgent/Main.cpp
+++ b/ext/common/agents/HelperAgent/Main.cpp
@@ -504,7 +504,7 @@ initializeNonPrivilegedWorkingObjects() {
 	wo->appPool = boost::make_shared<Pool>(wo->spawnerFactory, agentsOptions);
 	wo->appPool->initialize();
 	wo->appPool->setMax(options.getInt("max_pool_size"));
-	wo->appPool->setMaxIdleTime(options.getInt("pool_idle_time") * 1000000);
+	wo->appPool->setMaxIdleTime(options.getInt("pool_idle_time") * 1000000LL);
 	wo->appPool->enableSelfChecking(options.getBool("selfchecks"));
 	wo->appPool->abortLongRunningConnectionsCallback = abortLongRunningConnections;
 


### PR DESCRIPTION
PassengerPoolIdleTime cannot be set greater than 4294 (2 ** 32 / 1000000) because of integer overflow.