### PR TITLE
Error message prints command that failed

### DIFF
--- a/ext/common/Utils.cpp
+++ b/ext/common/Utils.cpp
@@ -1081,7 +1081,7 @@ runCommandAndCaptureOutput(const char **command) {
 				syscalls::kill(SIGKILL, pid);
 				syscalls::waitpid(pid, NULL, 0);
 				throw SystemException(string("Cannot read output from the '") +
-					command[1] + "' command", e);
+					command[0] + "' command", e);
 			}
 			done = ret == 0;
 			result.append(buf, ret);


### PR DESCRIPTION
If 'ps' isn't on your path for example, this error message gets triggered with the error message:
ERROR: The '-opid,ppid,%cpu,rss,vsize,pgid,uid,command' command failed
Expected: The 'ps' command failed
Fixes [Issue 1397](https://github.com/phusion/passenger/issues/1397)