### PR TITLE
Remove erroneous include statement for FreeBSD

### DIFF
--- a/ext/common/Utils/SystemMetricsCollector.h
+++ b/ext/common/Utils/SystemMetricsCollector.h
@@ -55,7 +55,6 @@
 #endif
 #ifdef __FreeBSD__
 	#include <sys/param.h>
-	#include <sys/pcpu.h>
 	#include <sys/sysctl.h>
 	#include <sys/resource.h>
 	#include <vm/vm_param.h>


### PR DESCRIPTION
I don't think we should include `sys/pcpu.h` here. It leads to the build error described in https://github.com/phusion/passenger/issues/1401

This PR should fix it. On my FreeBSD 10.1 box, the build error did not occur anymore!

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>