### PR TITLE
Check if the railties gem exists before trying to load files from it

### DIFF
--- a/lib/phusion_passenger/loader_shared_helpers.rb
+++ b/lib/phusion_passenger/loader_shared_helpers.rb
@@ -293,7 +293,7 @@ module PhusionPassenger
     def after_loading_app_code(options)
       # Post-install framework extensions. Possibly preceded by a call to
       # PhusionPassenger.install_framework_extensions!
-      if defined?(::Rails) && !defined?(::Rails::VERSION)
+      if defined?(::Rails) && !defined?(::Rails::VERSION) && Gem::Specification.find_all_by_name('railties').any?
         require 'rails/version'
       end
     end


### PR DESCRIPTION
We've had a problem where the actionview gem is included in a non-rails project.
In an upgrade of actionview, the gem `rails-html-sanitizer` was added as an dependency.
This `rails-html-sanitizer` gem defines some stuff in the ::Rails namespace which results in the 'rails/version' file being required.

In a project without railties this results in a LoadError on boot.