### PR TITLE
Update config.erb

### DIFF
--- a/resources/templates/standalone/config.erb
+++ b/resources/templates/standalone/config.erb
@@ -173,7 +173,7 @@ http {
         <% end %>
 
         # Rails asset pipeline support.
-        location ~ "^/assets/.+-[0-9a-f]{32}\..+" {
+        location ~ "^/assets/.+-([0-9a-f]{32}|[0-9a-f]{64})\..+" {
             error_page 490 = @static_asset;
             error_page 491 = @dynamic_request;
             recursive_error_pages on;


### PR DESCRIPTION
Sprockets 3.x started to use SHA256 digests which are 64 characters in length (see April 12th in https://github.com/rails/sprockets/blob/master/CHANGELOG.md).