### PR TITLE
PM2 Compatibility

### DIFF
--- a/src/helper-scripts/node-loader.js
+++ b/src/helper-scripts/node-loader.js
@@ -251,9 +251,11 @@ function shutdown() {
 	} catch (e) {
 		// Ignore error.
 	}
-	if (PhusionPassenger.listeners('exit').length == 0) {
-		process.exit(0);
-	} else {
+	if (PhusionPassenger.listeners('exit').length > 0) {
 		PhusionPassenger.emit('exit');
+	} else if (process.listeners('message').length > 0) {
+		process.emit('message', 'shutdown');
+	} else {
+		process.exit(0);
 	}
 }


### PR DESCRIPTION
Allow node apps to listen for shutdown without being aware of Phusion Passenger.

This allows apps which were written for PM2 graceful shutdown to be run in Phusion Passenger with no changes.