### PR TITLE
use a non-empty string to disable mod_autoindex

### DIFF
--- a/src/apache2_module/Hooks.cpp
+++ b/src/apache2_module/Hooks.cpp
@@ -1512,7 +1512,7 @@ public:
 		RequestNote *note = getRequestNote(r);
 		if (note != 0 && hasModAutoIndex()) {
 			note->handlerBeforeModAutoIndex = r->handler;
-			r->handler = "";
+			r->handler = "passenger-skip-autoindex";
 		}
 		return DECLINED;
 	}


### PR DESCRIPTION
Since 2.4.10, the handler name of an empty string
signifies the default handler.  Since 2.4.17,
mod_autoindex will run even if mod_mime has not
classified this request as DIR_MAGIC_TYPE and
no other module has staked claim to th request
via a non-default r->handler.