### PR TITLE
add support for GNU/kFreeBSD

### DIFF
--- a/src/cxx_supportlib/BackgroundEventLoop.cpp
+++ b/src/cxx_supportlib/BackgroundEventLoop.cpp
@@ -43,7 +43,7 @@
 #ifndef HAVE_KQUEUE
 	#if defined(__APPLE__) || \
 		defined(__DragonFly__) || \
-		defined(__FreeBSD__) || \
+		defined(__FreeBSD_kernel__) || \
 		defined(__OpenBSD__) || \
 		defined(__NetBSD__)
 		#define HAVE_KQUEUE 1

--- a/src/cxx_supportlib/vendor-modified/psg_sysqueue.h
+++ b/src/cxx_supportlib/vendor-modified/psg_sysqueue.h
@@ -35,6 +35,7 @@
 #ifndef _PSG_SYSQUEUE_H_
 #define _PSG_SYSQUEUE_H_
 #define _SYS_QUEUE_H_ /* override system sys/queue.h */
+#define __SYS_QUEUE_H_ /* override GNU/kFreeBSD kglue/sys/queue.h */
 
 #include <stddef.h>
 

--- a/src/ruby_native_extension/passenger_native_support.c
+++ b/src/ruby_native_extension/passenger_native_support.c
@@ -62,7 +62,7 @@
 #ifdef HAVE_ALLOCA_H
 	#include <alloca.h>
 #endif
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
 	#define HAVE_KQUEUE
 	#include <sys/event.h>
 	#include <sys/time.h>


### PR DESCRIPTION
This fixes the build on Debian GNU/kFreeBSD:
https://bugs.debian.org/815242#19
though it was suggested I send it upstream.  Thanks!

Use kqueue on any platform having the FreeBSD kernel;  not just
FreeBSD itself.

Also define __SYS_QUEUE_H_ as an additional guard macro in
psg_sysqueue.h, which is something used by GNU/kFreeBSD only.