### PR TITLE
nginx: fixed building as a dynamic module

### DIFF
--- a/src/nginx_module/config
+++ b/src/nginx_module/config
@@ -20,6 +20,10 @@ if test "x$PASSENGER_LIBS" = "x" && ! $PASSENGER_CONFIG --compiled; then
     if ! cd $ngx_addon_dir; then
         exit 1
     fi
+    if [ "$ngx_module_link" = DYNAMIC ]; then
+        EXTRA_CXXFLAGS="-fPIC"
+        export EXTRA_CXXFLAGS
+    fi
     if test "x$TRACE" = 1; then
         if ! rake --trace nginx CACHING=false; then
             exit 1


### PR DESCRIPTION
Building passenger using the "--add-dynamic-module" configure option in nginx >= 1.9.11 leads to linking errors like the following one:

    /usr/bin/ld: /home/defan/src/nginx-1.9.12/passenger-5.0.26/buildout/common/libpassenger_common/Logging.o: relocation R_X86_64_32 against `.bss' can not be used when making a shared object; recompile with -fPIC
    /home/defan/src/nginx-1.9.12/passenger-5.0.26/buildout/common/libpassenger_common/Logging.o: could not read symbols: Bad value
    collect2: ld returned 1 exit status
    make[1]: *** [objs/ngx_http_passenger_module.so] Error 1
    make[1]: Leaving directory `/home/defan/src/nginx-1.9.12'
    make: *** [build] Error 2

The proposed patch adds "-fPIC" as a global EXTRA_CXXFLAGS variable that is being used later by rake.

Tested with nginx/1.9.12 + Passenger 5.0.26 on CentOS 6.7.