### PR TITLE
Fix rails server not properly loading dependencies

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/rack_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack_handler.rb
@@ -33,6 +33,9 @@ require 'phusion_passenger'
 ## Magic comment: end bootstrap ##
 
 PhusionPassenger.locate_directories
+# NOTE: Prevents `rails server` breaking due to `config/environment.rb`
+# using the `public_api` module.
+PhusionPassenger.require_passenger_lib('public_api')
 
 require 'rbconfig'
 


### PR DESCRIPTION
As title suggest, the issue is applicable when passenger is started using `rails s`. It tries to use the `on_event` method available in the `public_api.rb` module. The module does not get required using `rails s`. However it works fine with `passenger start`. 

`Gemfile`:

```
...
  gem 'passenger', '>= 5.0.25', require: 'phusion_passenger/rack_handler'
...
```

`Gemfile.lock`:

```
...
    passenger (5.0.26)
  passenger (>= 5.0.25)
...
```

`config/application.rb`

```
# Load the Rails application.
require File.expand_path('../application', __FILE__)

if defined?(PhusionPassenger)
  PhusionPassenger.on_event(:starting_worker_process) do |_forked|
    .......................
  end
end

# Initialize the Rails application.
Rails.application.initialize!
```


Backtrace:

```
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.x-compliant syntax, but you are running 2.3.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> Booting Passenger application server
=> Rails 4.2.5.2 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
Exiting
/home/syndbg/work/tradeo/uiapp/config/environment.rb:5:in `<top (required)>': undefined method `on_event' for PhusionPassenger:Module (NoMethodError)
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/activesupport-4.2.5.2/lib/active_support/dependencies.rb:274:in `require'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/activesupport-4.2.5.2/lib/active_support/dependencies.rb:274:in `block in require'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/activesupport-4.2.5.2/lib/active_support/dependencies.rb:240:in `load_dependency'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/activesupport-4.2.5.2/lib/active_support/dependencies.rb:274:in `require'
        from /home/syndbg/work/tradeo/uiapp/config.ru:3:in `block in <main>'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/builder.rb:55:in `instance_eval'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/builder.rb:55:in `initialize'
        from /home/syndbg/work/tradeo/uiapp/config.ru:in `new'
        from /home/syndbg/work/tradeo/uiapp/config.ru:in `<main>'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/builder.rb:49:in `eval'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/builder.rb:49:in `new_from_string'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/builder.rb:40:in `parse_file'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/server.rb:299:in `build_app_and_options_from_config'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/server.rb:208:in `app'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/server.rb:61:in `app'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/server.rb:336:in `wrapped_app'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/server.rb:139:in `log_to_stdout'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/server.rb:78:in `start'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/commands_tasks.rb:80:in `block in server'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/commands_tasks.rb:75:in `tap'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/commands_tasks.rb:75:in `server'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5.2/lib/rails/commands.rb:17:in `<top (required)>'
        from /home/syndbg/work/tradeo/uiapp/bin/rails:9:in `require'
        from /home/syndbg/work/tradeo/uiapp/bin/rails:9:in `<top (required)>'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/client/rails.rb:28:in `load'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/client/rails.rb:28:in `call'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/client/command.rb:7:in `call'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/client.rb:28:in `run'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/bin/spring:49:in `<top (required)>'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/binstub.rb:11:in `load'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.6.4/lib/spring/binstub.rb:11:in `<top (required)>'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/syndbg/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/syndbg/work/tradeo/uiapp/bin/spring:13:in `<top (required)>'
        from bin/rails:3:in `load'
        from bin/rails:3:in `<main>'

```



The solution was just to require the `public_api.rb` module. 


@OnixGH @FooBarWidget 