### PR TITLE
add CORS header to rails font assets

### DIFF
--- a/resources/templates/standalone/rails_asset_pipeline.erb
+++ b/resources/templates/standalone/rails_asset_pipeline.erb
@@ -16,6 +16,10 @@ location @static_asset {
     expires max;
     add_header Cache-Control public;
     add_header ETag "";
+
+    if ($request_filename ~ "^.+(eot|svg|ttf|otf|woff2|woff)$") {
+      add_header "Access-Control-Allow-Origin" "*";
+    }
 }
 location @dynamic_request {
     passenger_enabled on;


### PR DESCRIPTION
After finally realize how passanger process rails assets on a heroku installation and what trouble comes with the default setup. Here is my request in improving the current situation.

My Setup: Rails v4.2 App, Bootstrap with glyphicons font (plus FontAwesome), Passenger v5.0.28, Heroku.

I really spend 3 hours in different solutions until I found this post about [CORS Font Issues With Rails, Heroku, CloudFront and Passenger](https://nisdom.com/blog/2014/09/13/cors-font-issues-with-rails/) from Orest that got me on the right path.

> TL;DR – Solution;
> 
> You need to get Passenger’s nginx template, modify it to attach CORS headers and use it instead of the default one.

So the suggestion is, to duplicate passengers default standalone nginx config and add some custom rules to allow `Access-Control-Allow-Origin` for example.
These custom configuration template can be loaded by `--nginx-config-template` flag [(documentation)](https://www.phusionpassenger.com/library/config/standalone/reference/#--nginx-config-template-nginx_config_template). Well, this works. But it feels wrong, if you only want to fix font loading issues.

As also pointed out in the [documentation](https://www.phusionpassenger.com/library/config/standalone/reference/#--nginx-config-template-nginx_config_template) this comes with warnings. Now, with every passenger release I have to check if the original configuration template add features/modifications and patch my config. In the worst case, Passenger Standalone might even malfunction, as pointed out in the Docs.
##### What is the issue for the User?

Chrome or Firefox didn't display any fonts or iconfonts. Their Same Origin Policy disallows reading the remote resource without `Access-Control-Allow-Origin` headers.
##### Why?

Passenger standalone gem is installing its own nginx configuration. Which act greedy in deliver assets.

```
# resources/templates/standalone/rails_asset_pipeline.erb
# Rails asset pipeline support.
location ~ "^/assets/.+-([0-9a-f]{32}|[0-9a-f]{64})\..+" {…}
```

In short, nginx process every request that match `/assets/*` location.
Only files that didn’t exist get passed to process by the application server.

If you try to use passenger with [font_assets gem](https://github.com/ericallam/font_assets) or setup rails to use [rack-cors](https://github.com/cyu/rack-cors) or want to use new Rails 5 `config.public_file_server.headers = {}` - well, there will be **no success**.

Hongli Lai, pointed out on the phusion-passenger mailing list [once](https://groups.google.com/forum/#!topic/phusion-passenger/nskVxnxFssA) to preventing Heroku from precompiling your assets. But as @brandonhilkert responded, hosting assets from Nginx was one of the benefits of using Passsenger on heroku. True in my point of view.

`--nginx-config-template` is an valid workaround but the costs to maintain this solution is hight.
##### Better default configuration

The build-in passenger nginx config should also handle font assets and set the `Access-Control-Allow-Origin` header by default.

Delivering fonts should be work out-of-the-box without any custom setup.

Of course, to be discussed/improved if the value can be customized to some specific origin. Or if a new flag like `--rails-app-settings` is a possible future solution.
###### test CORS Header with

``` bash
curl -I -s -X GET -H "Origin: *" http://example.herokuapp.com/assets/bootstrap/glyphicons-halflings-regular.eot
```

Just want good passenger defaults, please be nice 🌻  
