### PR TITLE
prevent serializing the socket

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
+++ b/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
@@ -275,6 +275,10 @@ module PhusionPassenger
         return exception.instance_variable_get(:"@from_unseekable_socket") == @socket.object_id
       end
 
+      def to_hash
+        {socket:"Not JSON Encodable",eof: @simulate_eof}
+      end
+
     private
       def annotate(exception)
         exception.instance_variable_set(:"@from_unseekable_socket", @socket.object_id)

--- a/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
+++ b/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
@@ -276,7 +276,7 @@ module PhusionPassenger
       end
 
       def to_hash
-        {socket:"Not JSON Encodable",eof: @simulate_eof}
+        {:socket => "Not JSON Encodable", :eof => @simulate_eof}
       end
 
     private


### PR DESCRIPTION
when our unseekable_socket get's turned into a hash, don't include the socket.