### PR TITLE
Fix compilation warning with gcc 5.4.0 under Ubuntu 16.04/ppc64le

### DIFF
--- a/src/nginx_module/ContentHandler.c
+++ b/src/nginx_module/ContentHandler.c
@@ -446,6 +446,8 @@ prepare_request_buffer_construction(ngx_http_request_t *r, passenger_context_t *
         state->content_length.len = ngx_snprintf(state->content_length.data,
             sizeof("4294967295") - 1, "%O", r->headers_in.content_length_n)
             - state->content_length.data;
+    } else {
+        state->content_length.len = 0;
     }
 
     state->core_password.data = (u_char *) psg_watchdog_launcher_get_core_password(


### PR DESCRIPTION
Recently I got the following warning during compilation of nginx with passenger module:

    extra/passenger-5.0.26/src/nginx_module/ContentHandler.c: In function ‘create_request’:
    extra/passenger-5.0.26/src/nginx_module/ContentHandler.c:762:36: error: ‘state.content_length.len’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         buffer_construction_state      state;
                                        ^

OS details:

    $ uname -rvmpi
    4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:30:22 UTC 2016 ppc64le ppc64le ppc64le

Compiler details:

    $ gcc -v
    Using built-in specs.
    COLLECT_GCC=gcc
    COLLECT_LTO_WRAPPER=/usr/lib/gcc/powerpc64le-linux-gnu/5/lto-wrapper
    Target: powerpc64le-linux-gnu
    Configured with: ../src/configure -v --with-pkgversion='Ubuntu/IBM 5.4.0-6ubuntu1~16.04.1' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-ppc64el/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-ppc64el --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-ppc64el --with-arch-directory=ppc64le --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-secureplt --with-cpu=power8 --enable-targets=powerpcle-linux --disable-multilib --enable-multiarch --disable-werror --with-long-double-128 --enable-checking=release --build=powerpc64le-linux-gnu --host=powerpc64le-linux-gnu --target=powerpc64le-linux-gnu
    Thread model: posix
    gcc version 5.4.0 20160609 (Ubuntu/IBM 5.4.0-6ubuntu1~16.04.1)

It's interesting that the same gcc 5.4.0 under Ubuntu 16.04/x86_64 does not produce this warning.

Anyway, the reported problem looks valid and I hope that the proposed patch is good enough to eliminate it.