### PR TITLE
Node loader linting

### DIFF
--- a/src/nodejs_supportlib/phusion_passenger/line_reader.js
+++ b/src/nodejs_supportlib/phusion_passenger/line_reader.js
@@ -62,7 +62,7 @@ function LineReader(stream) {
 	}
 
 	function onData(data) {
-		var index, line, callback;
+		var index, line;
 
 		if (self.buffer == undefined) {
 			// Already closed.
@@ -100,19 +100,19 @@ LineReader.prototype.close = function() {
 	this._pause();
 	this.buffer = undefined;
 	this.lines = undefined;
-}
+};
 
 LineReader.prototype.isClosed = function() {
 	return this.buffer === undefined;
-}
+};
 
 LineReader.prototype.endReached = function() {
 	return this.eof;
-}
+};
 
 LineReader.prototype.lineBufferIsFull = function() {
 	return this.lines.length > 0;
-}
+};
 
 LineReader.prototype.readLine = function(callback) {
 	if (this.lines.length > 0) {
@@ -128,7 +128,7 @@ LineReader.prototype.readLine = function(callback) {
 	} else {
 		this.callbacks.push(callback);
 	}
-}
+};
 
 LineReader.prototype._autoPauseOrResume = function() {
 	if (this.buffer != undefined) {
@@ -138,20 +138,20 @@ LineReader.prototype._autoPauseOrResume = function() {
 			this._resume();
 		}
 	}
-}
+};
 
 LineReader.prototype._pause = function() {
 	if (!this.paused) {
 		this.paused = true;
 		this.stream.pause();
 	}
-}
+};
 
 LineReader.prototype._resume = function() {
 	if (this.paused) {
 		this.paused = false;
 		this.stream.resume();
 	}
-}
+};
 
 exports.LineReader = LineReader;

--- a/src/nodejs_supportlib/phusion_passenger/log_express.js
+++ b/src/nodejs_supportlib/phusion_passenger/log_express.js
@@ -67,11 +67,11 @@ exports.initPreLoad = function() {
 			}
 
 			return express.application.useOrig.apply(this, arguments);
-		}
+		};
 	} catch (e) {
 		log.error("Unable to instrument Express due to error: " + e);
 	}
-}
+};
 
 exports.initPostLoad = function() {
 	if (!express) {
@@ -86,7 +86,7 @@ exports.initPostLoad = function() {
 	} catch (e) {
 		log.error("Unable to instrument Express error flow due to error: " + e);
 	}
-}
+};
 
 function logRequest(req, res, next) {
 	log.verbose("==== Instrumentation [Express] ==== REQUEST [" + req.method + " " + req.url + "] attach");

--- a/src/nodejs_supportlib/phusion_passenger/log_mongodb.js
+++ b/src/nodejs_supportlib/phusion_passenger/log_mongodb.js
@@ -65,9 +65,8 @@ function instrumentCollectionMethod(origParent, functionName, newFn) {
 }
 
 function collectionFn(origArguments, databaseName, collectionName, functionName, originalFn) {
-	var friendlyName = databaseName + "." + collectionName + "." + functionName + "(..)";
 	var query = "";
-	for (i = 0; i < origArguments.length; i++) {
+	for (var i = 0; i < origArguments.length; i++) {
 		if (typeof(origArguments[i]) != 'function') { // mongoskin
 			query += (i > 0 ? "," : "") + JSON.stringify(origArguments[i]);
 		}
@@ -111,13 +110,13 @@ exports.initPreLoad = function() {
 	wrapRepairCLSMongoskinUtils(appRoot);
 
 	try {
-		for (i = 0; i < collectionMethods.length; i++) {
+		for (var i = 0; i < collectionMethods.length; i++) {
 			instrumentCollectionMethod(mongodb.Collection.prototype, collectionMethods[i], collectionFn);
 		}
 	} catch (e) {
 		log.error("Unable to instrument MongoDB due to error: " + e);
 	}
-}
+};
 
 function wrapRepairCLSMongo14() {
 	try {
@@ -139,7 +138,7 @@ function wrapRepairCLSMongo14() {
 			} else {
 				this._passenger_wrapped__executeQueryCommand.apply(this, arguments);
 			}
-		}
+		};
 
 		mongodb.Db.prototype._passenger_wrapped__executeInsertCommand = mongodb.Db.prototype._executeInsertCommand;
 		mongodb.Db.prototype._executeInsertCommand = function() {
@@ -154,7 +153,7 @@ function wrapRepairCLSMongo14() {
 			} else {
 				this._passenger_wrapped__executeInsertCommand.apply(this, arguments);
 			}
-		}
+		};
 		log.verbose("Using MongoDB 1.4.x continuation-local-storage workaround");
 	} catch (e) {
 		log.error("Not using MongoDB continuation-local-storage workaround: " + e);
@@ -185,10 +184,10 @@ function wrapRepairCLSMongoskinUtils(appRoot) {
 			skinClass.prototype.open = function(callback) {
 				// Finally we can bind the callback so that when the emitter calls it, the cls is mapped correctly.
 				return skinClass.prototype._passenger_wrapped_open.call(this, ustReporter.getCLSWrappedCallback(callback));
-			}
+			};
 
 			return skinClass;
-		}
+		};
 		log.verbose("Using mongoskin continuation-local-storage workaround");
 	} catch (e) {
 		log.error("Not using mongoskin continuation-local-storage workaround (probably an unsupported version): " + e);
@@ -199,5 +198,5 @@ exports.initPostLoad = function() {
 	//if (!mongodb) {
 	//	return;
 	//}
-}
+};
 

--- a/src/nodejs_supportlib/phusion_passenger/ustreporter.js
+++ b/src/nodejs_supportlib/phusion_passenger/ustreporter.js
@@ -45,14 +45,14 @@ var appRoot;
  */
 exports.getPassengerLogger = function() {
 	return log;
-}
+};
 
 /**
  * @return the application root path, needed for instrumenting an application's node modules.
  */
 exports.getApplicationRoot = function() {
 	return appRoot;
-}
+};
 
 /**
  * @return timestamp in microseconds to be used as the start or end timestamp for timed logging (monotonic clock, not wall clock).
@@ -60,7 +60,7 @@ exports.getApplicationRoot = function() {
 exports.nowTimestamp = function() {
 	var secAndUsec = process.hrtime();
 	return Math.round((secAndUsec[0] * 1e6) + (secAndUsec[1] / 1e3));
-}
+};
 
 /**
  * All Activity logs will be dropped unless they are done after this method, from within an execution chain starting with the callback. So it is
@@ -102,28 +102,28 @@ exports.attachToRequest = function(request, response, callback) {
 	} catch (e) {
 		log.error("Dropping Union Station request log due to error:\n" + e.stack);
 	}
-}
+};
 
 /**
  * Log a timed block, described by activityName, with an optional message to display (e.g. in a mouseover).
  */
 exports.logTimedActivityGeneric = function(activityName, tBegin, tEnd, message) {
 	logTimedActivity(activityName, tBegin, tEnd, "generic", message ? { "message": message } : undefined);
-}
+};
 
 /**
  * Log a timed mongo database interaction block, described by activityName, with an optional query to display (e.g. in a mouseover).
  */
 exports.logTimedActivityMongo = function(activityName, tBegin, tEnd, query) {
 	logTimedActivity(activityName, tBegin, tEnd, "mongo", query ? { "query": query } : undefined);
-}
+};
 
 /**
  * Log a timed SQL database interaction block, described by activityName, with an optional query to display (e.g. in a mouseover).
  */
 exports.logTimedActivitySQL = function(activityName, tBegin, tEnd, query) {
 	logTimedActivity(activityName, tBegin, tEnd, "sql", query ? { "query": query } : undefined);
-}
+};
 
 /**
  * Internal, base for the public logTimedActivity...()
@@ -198,7 +198,7 @@ exports.logException = function(name, message, trace) {
 	} catch (e) {
 		log.error("Dropping Union Station exception log due to error:\n" + e.stack);
 	}
-}
+};
 
 /**
  * Get the current request transaction id necessary to append logs to it. This is normally done automatically, but some modules break automatic attachment
@@ -215,7 +215,7 @@ exports.getCurrentTxnId = getCurrentTxnId;
  */
 exports.getCLSWrappedCallback = function(origCallback) {
 	return reqNamespace.bind(origCallback);
-}
+};
 
 /**
  * For internal use. Called by Passenger loader, no need to call from anywhere else.
@@ -224,4 +224,4 @@ exports.init = function(logger, applicationRoot, ustLogger) {
 	log = logger;
 	appRoot = applicationRoot;
 	ustLog = ustLogger;
-}
+};


### PR DESCRIPTION
We're working on highly efficient micro-services which handles hundred thousands of requests per second. Phusion Passenger is great tool for nodejs apps, thank you for this.

During optimisation process the idea to check sources related to nodejs in Phusion Passenger come to mind. We prefer always `strict mode` and strict linting/formatting for our code.

We have run our pre-publish tools over your nodejs related code. And came up with this PR:

node-loader.js
 - Minor indentation and mixed spaces/tabs indentation fix
 - Move `doListen` and `doneListening` out of `installServer` function scope

ustrouter_connector.js
 - `i` is not defined in various `for` loops
 - define other not defined variables
 - Minor indentation and mixed spaces/tabs indentation fix

ustreporter.js
 - Missed semicolons

log_mongodb.js
 - `i` is not defined in `for` loops
 - Various missed semicolons
 - `friendlyName` defined but never used

log_express.js
 - Missed semicolons

line_reader.js
 - Missed semicolons
 - Unused variables

Changes was tested on Dev and Prod environments.