### PR TITLE
Group::allEnabledProcessesAreTotallyBusy() should return false if there are no enabled processes.

### DIFF
--- a/src/agent/Core/ApplicationPool/Group/StateInspection.cpp
+++ b/src/agent/Core/ApplicationPool/Group/StateInspection.cpp
@@ -77,7 +77,7 @@ Group::processUpperLimitsReached() const {
  */
 bool
 Group::allEnabledProcessesAreTotallyBusy() const {
-	return nEnabledProcessesTotallyBusy == enabledCount;
+	return nEnabledProcessesTotallyBusy == enabledCount && enabledCount > 0;
 }
 
 /**


### PR DESCRIPTION
According to the [comment](https://github.com/phusion/passenger/blob/3795b6188bf8164a0a843f19e90c65c1f38e07cc/src/agent/Core/ApplicationPool/Group/StateInspection.cpp#L76) in `src/agent/Core/ApplicationPool/Group/StateInspection.cpp`, the function `Group::allEnabledProcessesAreTotallyBusy()` is supposed to return false if there are no enabled processes. But actually it returns true.

As a result, setting `PassengerMinInstances` to `0` does not work as expected. If you kill last process in an application, a new process is spawned immediately (Passenger behaves like as if `PassengerMinInstances` is set to `1`).