### PR TITLE
Prespawn helper fix when not listening on localhost.

### DIFF
--- a/src/helper-scripts/prespawn
+++ b/src/helper-scripts/prespawn
@@ -126,9 +126,13 @@ class TCPPrespawnLocation < PrespawnLocation
   end
 
   def connect
-    TCPSocket.new('127.0.0.1', request_port)
+    TCPSocket.new(@uri.host, request_port)
   rescue Errno::ECONNREFUSED
-    TCPSocket.new('::1', request_port)
+    begin
+      TCPSocket.new('127.0.0.1', request_port)
+    rescue Errno::ECONNREFUSED
+      TCPSocket.new('::1', request_port)
+    end
   end
 end
 


### PR DESCRIPTION
The prespawn script bind to 127.0.0.1 or, failing that, ::1.  This fix
try first to bind to @uri.host.

Authored-by: Camden Narzt

Signed-off-by: Fabio Inguaggiato <fabio.inguaggiato@gmail.com>