### PR TITLE
Python3 loader `decode()` encoding fix. Fixes #1935

### DIFF
--- a/src/helper-scripts/wsgi-loader.py
+++ b/src/helper-scripts/wsgi-loader.py
@@ -123,7 +123,7 @@ if sys.version_info[0] >= 3:
 		raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
 
 	def bytes_to_str(b):
-		return b.decode()
+		return b.decode('latin-1')
 
 	def str_to_bytes(s):
 		return s.encode('latin-1')


### PR DESCRIPTION
 #1935. I also get this error with some GEOIP headers.
```
File \"/helper-scripts/wsgi-loader.py\", line 125, in bytes_to_str
return b.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 1: invalid continuation byte"
```