### PR TITLE
Backport Python3 loader `decode()` encoding fix.

### DIFF
--- a/helper-scripts/wsgi-loader.py
+++ b/helper-scripts/wsgi-loader.py
@@ -122,7 +122,7 @@ if sys.version_info[0] >= 3:
 		raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
 
 	def bytes_to_str(b):
-		return b.decode()
+		return b.decode('latin-1')
 
 	def str_to_bytes(s):
 		return s.encode('latin-1')


### PR DESCRIPTION
Backport for #1937 