### PR TITLE
Make nginx engine started by standalone stop gracefully

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/standalone/start_command/nginx_engine.rb
+++ b/src/ruby_supportlib/phusion_passenger/standalone/start_command/nginx_engine.rb
@@ -154,6 +154,10 @@ module PhusionPassenger
             :start_command => "#{Shellwords.escape @nginx_binary} " +
               "-c #{Shellwords.escape nginx_config_path} " +
               "-p #{Shellwords.escape @working_dir}",
+            :stop_command => "#{Shellwords.escape @nginx_binary} " +
+              "-c #{Shellwords.escape nginx_config_path} " +
+              "-p #{Shellwords.escape @working_dir} " +
+              "-s quit",
             :ping_command  => ping_spec,
             :pid_file      => @options[:pid_file],
             :log_file      => @options[:log_file],


### PR DESCRIPTION
Solves Nginx engine part in #1598 

Tested manually locally
Don't know how to auto-test this

The config path is necessary, not sure about working dir (but harmless to pass it I guess)