### PR TITLE
Do not hardcode bash(1) location

### DIFF
--- a/dev/ci/lib/functions.sh
+++ b/dev/ci/lib/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 RESET=$(echo -e "\033[0m")

--- a/dev/ci/lib/set-container-envvars.sh
+++ b/dev/ci/lib/set-container-envvars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Do not `set -e` here because debug-console-wrapper.sh
 # relies on this fact.
 

--- a/dev/ci/lib/setup-container.sh
+++ b/dev/ci/lib/setup-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! grep -q passenger.test /etc/hosts; then
 	header2 "Updating /etc/hosts"

--- a/dev/ci/run-tests-natively
+++ b/dev/ci/run-tests-natively
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/run-tests-with-docker
+++ b/dev/ci/run-tests-with-docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/scripts/debug-console-wrapper.sh
+++ b/dev/ci/scripts/debug-console-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/scripts/docker-entrypoint-stage2.sh
+++ b/dev/ci/scripts/docker-entrypoint-stage2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=/passenger/dev/ci/scripts

--- a/dev/ci/scripts/docker-entrypoint.sh
+++ b/dev/ci/scripts/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=/passenger/dev/ci/scripts

--- a/dev/ci/scripts/inituidgid
+++ b/dev/ci/scripts/inituidgid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 chown -R "$APP_UID:$APP_GID" /home/app

--- a/dev/ci/scripts/run-tests-natively-stage2.sh
+++ b/dev/ci/scripts/run-tests-natively-stage2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/scripts/setup-host-natively.sh
+++ b/dev/ci/scripts/setup-host-natively.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/setup-host
+++ b/dev/ci/setup-host
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 SELFDIR=$(dirname "$0")

--- a/dev/ci/tests/apache2/run
+++ b/dev/ci/tests/apache2/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run ./bin/passenger-install-apache2-module --auto

--- a/dev/ci/tests/apache2/setup
+++ b/dev/ci/tests/apache2/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes NODE_MODULES=yes

--- a/dev/ci/tests/cxx/run
+++ b/dev/ci/tests/cxx/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 header2 "Running C++ tests"

--- a/dev/ci/tests/cxx/setup
+++ b/dev/ci/tests/cxx/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes

--- a/dev/ci/tests/debian/run
+++ b/dev/ci/tests/debian/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is from the "Passenger Debian packaging test" Jenkins job. It builds
 # packages for a specific distribution and architecture and runs tests on the resulting packages.
 #

--- a/dev/ci/tests/nginx-dynamic/run
+++ b/dev/ci/tests/nginx-dynamic/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 TEST_DYNAMIC_WITH_NGINX_VERSION=1.12.1

--- a/dev/ci/tests/nginx-dynamic/setup
+++ b/dev/ci/tests/nginx-dynamic/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes

--- a/dev/ci/tests/nginx/run
+++ b/dev/ci/tests/nginx/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run ./bin/passenger-install-nginx-module --auto --prefix=/tmp/nginx --auto-download

--- a/dev/ci/tests/nginx/setup
+++ b/dev/ci/tests/nginx/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes NODE_MODULES=yes

--- a/dev/ci/tests/nodejs/run
+++ b/dev/ci/tests/nodejs/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run bundle exec drake "-j$COMPILE_CONCURRENCY" test:node

--- a/dev/ci/tests/nodejs/setup
+++ b/dev/ci/tests/nodejs/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes NODE_MODULES=yes

--- a/dev/ci/tests/rpm/run
+++ b/dev/ci/tests/rpm/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is from the "Passenger RPM packaging test" Jenkins job. It builds
 # packages for a specific distribution and architecture and runs tests on the resulting packages.
 #

--- a/dev/ci/tests/ruby/run
+++ b/dev/ci/tests/ruby/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run bundle exec drake "-j$COMPILE_CONCURRENCY" test:ruby

--- a/dev/ci/tests/ruby/setup
+++ b/dev/ci/tests/ruby/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes

--- a/dev/ci/tests/source-packaging/run
+++ b/dev/ci/tests/source-packaging/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run bundle exec drake "-j$COMPILE_CONCURRENCY" test:source_packaging

--- a/dev/ci/tests/source-packaging/setup
+++ b/dev/ci/tests/source-packaging/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes

--- a/dev/ci/tests/standalone/run
+++ b/dev/ci/tests/standalone/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 run bundle exec drake "-j$COMPILE_CONCURRENCY" test:integration:standalone

--- a/dev/ci/tests/standalone/setup
+++ b/dev/ci/tests/standalone/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 retry_run 3 rake test:install_deps BASE_DEPS=yes

--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 set -o pipefail
 

--- a/test/integration_tests/standalone_tests.rb
+++ b/test/integration_tests/standalone_tests.rb
@@ -74,7 +74,7 @@ describe "Passenger Standalone" do
   def create_dummy_support_binaries
     Dir.mkdir("support-binaries") if !File.exist?("support-binaries")
     File.open("support-binaries/#{AGENT_EXE}", "w") do |f|
-      f.puts "#!/bin/bash"
+      f.puts "#!/usr/bin/env bash"
       f.puts "echo PASS"
     end
     File.chmod(0755, "support-binaries/#{AGENT_EXE}")
@@ -82,7 +82,7 @@ describe "Passenger Standalone" do
 
   def create_dummy_nginx_binary
     File.open("PassengerWebHelper", "w") do |f|
-      f.puts "#!/bin/bash"
+      f.puts "#!/usr/bin/env bash"
       f.puts "echo nginx version: 1.0.0"
     end
     File.chmod(0755, "PassengerWebHelper")

--- a/test/ruby/standalone/runtime_installer_spec.rb
+++ b/test/ruby/standalone/runtime_installer_spec.rb
@@ -58,7 +58,7 @@ describe RuntimeInstaller do
   def create_dummy_support_binaries
     Dir.mkdir("support-binaries")
     File.open("support-binaries/#{AGENT_EXE}", "w") do |f|
-      f.puts "#!/bin/bash"
+      f.puts "#!/usr/bin/env bash"
       f.puts "echo PASS"
     end
     File.chmod(0755, "support-binaries/#{AGENT_EXE}")
@@ -66,7 +66,7 @@ describe RuntimeInstaller do
 
   def create_dummy_nginx_binary
     File.open("PassengerWebHelper", "w") do |f|
-      f.puts "#!/bin/bash"
+      f.puts "#!/usr/bin/env bash"
       f.puts "echo nginx version: 1.0.0"
     end
     File.chmod(0755, "PassengerWebHelper")
@@ -377,7 +377,7 @@ describe RuntimeInstaller do
         create_tarball(output) do
           Dir.mkdir("nginx-#{nginx_version}")
           File.open("nginx-#{nginx_version}/configure", "w") do |f|
-            f.puts("#!/bin/bash")
+            f.puts("#!/usr/bin/env bash")
             f.puts("echo error")
             f.puts("exit 1")
           end


### PR DESCRIPTION
Hardcoding `bash(1)` location is not portable.  Better rely on `env(1)` for finding `bash(1)` in `$PATH`.

For more details about this, you can refer to the wikipedia article about [shebang portability](https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability).