### PR TITLE
Download nginx over HTTPS

### DIFF
--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -306,7 +306,7 @@ private
     new_screen
     puts "<banner>Downloading Nginx...</banner>"
 
-    url = "http://www.nginx.org/download/nginx-#{PREFERRED_NGINX_VERSION}.tar.gz"
+    url = "https://www.nginx.org/download/nginx-#{PREFERRED_NGINX_VERSION}.tar.gz"
     dirname = "nginx-#{PREFERRED_NGINX_VERSION}"
     tarball = "#{@working_dir}/nginx.tar.gz"
 


### PR DESCRIPTION
Found out the firewall on a job was blocking the download over http.
Since nginx has a perfectly working ssl certificate, why not download it over https?

Tested on multiple servers and https is being accepted just fine. 