### PR TITLE
Fix for Windows Subsystem for Linux

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/platform_info/operating_system.rb
+++ b/src/ruby_supportlib/phusion_passenger/platform_info/operating_system.rb
@@ -239,6 +239,14 @@ module PhusionPassenger
       return File.exists?("/proc/xen/capabilities") && cpu_architectures[0] == "x86"
     end
     memoize :requires_no_tls_direct_seg_refs?, true
+
+    # Returns true if the current os is running in Windows Subsystem for Linux
+    def self.windows_subsystem?
+      uname = uname_command
+      raise "The 'uname' command cannot be found" if !uname
+      `#{uname} -r`.include?("Microsoft")
+    end
+    memoize :windows_subsystem?, true
   end
 
 end # module PhusionPassenger

--- a/src/ruby_supportlib/phusion_passenger/request_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/request_handler.rb
@@ -279,7 +279,10 @@ module PhusionPassenger
       # is still bugged as of version 1.7.0. They can
       # cause unexplicable freezes when used in combination
       # with threading.
-      return !@force_http_session && ruby_engine != "jruby"
+      # It's also bugged in Windows Subsystem for Linux
+      # as of Windows 10, version 1803 (Fall Creators Update)
+      # You will get "Address In Use" errors even if the port is unused.
+      return !@force_http_session && ruby_engine != "jruby" && !PlatformInfo.windows_subsystem?
     end
 
     def create_unix_socket_on_filesystem(options)


### PR DESCRIPTION
Fix passenger giving “address already in use” errors on WSL.

#2036
