### PR TITLE
Fixed nginx module building on CentOS 6

### DIFF
--- a/src/nginx_module/Configuration.c
+++ b/src/nginx_module/Configuration.c
@@ -1021,7 +1021,8 @@ passenger_postprocess_config(ngx_conf_t *cf)
         if (dump_file != NULL) {
             dump_content = psg_json_value_to_styled_string(
                 passenger_main_conf.manifest);
-            fwrite(dump_content, 1, strlen(dump_content), dump_file);
+            ssize_t ret = fwrite(dump_content, 1, strlen(dump_content), dump_file);
+            (void) ret; // Ignore compilation warning.
             fclose(dump_file);
             free(dump_content);
         } else {


### PR DESCRIPTION
Made the same approach as in apache2 module here:
https://github.com/phusion/passenger/blob/stable-5.3/src/apache2_module/Config.cpp#L164-L165

Fixed the following error during compilation on CentOS 6.9 (gcc 4.4.7, glibc 2.12):

```
make -f objs/Makefile modules
make[1]: Entering directory `/home/defan/rpmbuild/BUILD/nginx-module-passenger-1.13.10'
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /home/defan/rpmbuild/BUILD/nginx-module-passenger-1.13.10/passenger-5.2.3/src -I objs -I src/http -I src/http/modules \
		-o objs/addon/nginx_module/Configuration.o \
		passenger-5.2.3/src/nginx_module/Configuration.c
cc1: warnings being treated as errors
passenger-5.2.3/src/nginx_module/Configuration.c: In function ‘passenger_postprocess_config’:
passenger-5.2.3/src/nginx_module/Configuration.c:1024: error: ignoring return value of ‘fwrite’, declared with attribute warn_unused_result
make[1]: *** [objs/addon/nginx_module/Configuration.o] Error 1
make[1]: Leaving directory `/home/defan/rpmbuild/BUILD/nginx-module-passenger-1.13.10'
make: *** [modules] Error 2
```