### PR TITLE
Fix build with curl 7.62.0

### DIFF
--- a/src/agent/Core/SecurityUpdateChecker.h
+++ b/src/agent/Core/SecurityUpdateChecker.h
@@ -256,9 +256,11 @@ private:
 				error.append(" for proxy address " + sessionState.config["proxy_url"].asString());
 				break;
 
+#if LIBCURL_VERSION_NUM < 0x073e00
 			case CURLE_SSL_CACERT:
 				// Peer certificate cannot be authenticated with given / known CA certificates. This would happen
 				// for MITM but could also be a truststore issue.
+#endif
 			case CURLE_PEER_FAILED_VERIFICATION:
 				// The remote server's SSL certificate or SSH md5 fingerprint was deemed not OK.
 				error.append(" while connecting to " + sessionState.configRlz.url


### PR DESCRIPTION
from CHANGES:
ssl: deprecate CURLE_SSL_CACERT in favour of a unified error code
Long live CURLE_PEER_FAILED_VERIFICATION