### PR TITLE
Vagrant box provisioning: lock `rake` gem installation to v12.2.1

### DIFF
--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -48,7 +48,7 @@ apt-get install -y build-essential git bash-completion ccache wget \
 ### Install basic gems
 
 if [[ ! -e /usr/local/bin/rake ]]; then
-	gem install rake --no-rdoc --no-ri
+	gem install rake --no-rdoc --no-ri --version="=12.2.1"
 fi
 if [[ ! -e /usr/local/bin/drake ]]; then
 	gem install drake --no-rdoc --no-ri


### PR DESCRIPTION
The Vagrant dev box provisioning installs the rake gem. The gem release 12.3.0 upgraded the Ruby dependency to version 2.0. Since the box is a 14.04, which ships with Ruby 1.9.3, the dependency is now broken.

There are therefore two solutions: change the box to use Ruby 2.0, or use the previous rake release.

Based on the rake release history, such upgrade is due to reported problems with 1.9.3, however, assuming that the box itself worked fine before, such solution is likely less drastic and potentially problematic than swithing to Ruby 2.0.

Closes #2152.