### PR TITLE
Vagrant box provisioning: lock `bundler` gem installation to v1.15.4

### DIFF
--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -54,7 +54,7 @@ if [[ ! -e /usr/local/bin/drake ]]; then
 	gem install drake --no-rdoc --no-ri
 fi
 if [[ ! -e /usr/local/bin/bundler ]]; then
-	gem install bundler --no-rdoc --no-ri
+	gem install bundler --no-rdoc --no-ri --version="=1.15.4"
 fi
 
 


### PR DESCRIPTION
The current Bundler gem version, 2.0.1, doesn't support Ruby 1.9. This solution locks the installed version to the same present in `Gemfile.lock`, 1.15.4.

For additional comments, see commit 8627c933eb.

Closes #2161.