### PR TITLE
Vagrant box provisioning: fix nodejs-related packages (nodejs, yarn, npm)

### DIFF
--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -38,10 +38,15 @@ chmod 440 /etc/sudoers.d/passenger
 
 ### Install native dependencies
 
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+curl -sL https://deb.nodesource.com/setup_6.x | bash -
+
 apt-get update
 apt-get install -y build-essential git bash-completion ccache wget \
 	libxml2-dev libxslt1-dev libsqlite3-dev libcurl4-openssl-dev libpcre3-dev \
-	ruby ruby-dev nodejs npm \
+	ruby ruby-dev nodejs yarn \
 	apache2-mpm-worker apache2-threaded-dev
 
 


### PR DESCRIPTION
Fixes related to nodejs on the Vagrant box, required for a successful provisioning:

- yarn needs to be installed
- nodejs on Trusty is tool old to work with yarn
- npm conflicts with yarn

Closes #2155, although `rake test:cxx` will still fail.
