### PR TITLE
Vagrant box provisioning: update keys/certificates

### DIFF
--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -20,6 +20,13 @@ if ! grep -q passenger.test /etc/hosts; then
 fi
 
 
+### Update keys/certificates
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7F438280EF8D349F # Puppet
+
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --reinstall ca-certificates
+
+
 ### Update bashrc and bash profile
 
 if ! grep -q bashrc.mine /etc/bash.bashrc; then

--- a/dev/vagrant/provision.sh
+++ b/dev/vagrant/provision.sh
@@ -20,11 +20,18 @@ if ! grep -q passenger.test /etc/hosts; then
 fi
 
 
+### Preset dpkg
+
+# None of the packages to install require interaction, but a couple still expect an available
+# stdin. With this, they'll know it isn't.
+export DEBIAN_FRONTEND=noninteractive
+
+
 ### Update keys/certificates
 
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7F438280EF8D349F # Puppet
 
-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --reinstall ca-certificates
+apt-get update && apt-get install --reinstall ca-certificates
 
 
 ### Update bashrc and bash profile


### PR DESCRIPTION
The dev box has outdated keys/certificates:

- the Puppet APT repository key needs to be updated;
- the certificates also seem to be outdated, causing the Yarn APT repository update to fail.

See #2164 for the error details.

Closes #2164.