### PR TITLE
Allow remote requests to individual handlers, and know from where they came

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/request_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/request_handler.rb
@@ -310,9 +310,9 @@ module PhusionPassenger
     end
 
     def create_tcp_socket
-      # We use "127.0.0.1" as address in order to force
+      # We use "0.0.0.0" as address in order to force
       # TCPv4 instead of TCPv6.
-      socket = TCPServer.new('127.0.0.1', 0)
+      socket = TCPServer.new('0.0.0.0', 0)
       socket.listen(BACKLOG_SIZE)
       socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       socket.binmode

--- a/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb
@@ -267,6 +267,11 @@ module PhusionPassenger
             headers["SERVER_NAME"]     = "127.0.0.1"
             headers["SERVER_PORT"]     = connection.addr[1].to_s
             headers["SERVER_PROTOCOL"] = protocol
+            headers["REMOTE_PORT"],
+            headers["REMOTE_ADDR"]     = connection.to_io.is_a?(TCPSocket) ?
+                                           connection.to_io.peeraddr(:numeric)[1..2] :
+                                           [nil, '127.0.0.1']
+
           else
             header, value = line.split(/\s*:\s*/, 2)
             header.upcase!            # "Foo-Bar" => "FOO-BAR"


### PR DESCRIPTION
Passenger allows you to [send requests to individual handler processes](https://www.phusionpassenger.com/library/admin/nginx/request_individual_processes.html), which I find useful for flushing per-process data caches that work thousands of times faster than Memcached.

At the moment, such requests don't set the `REMOTE_ADDR` header, so Rails sees `request.remote_ip` as `nil`/blank. This PR sets both `REMOTE_ADDR` and `REMOTE_PORT` for such requests.

Secondly, per-process handlers currently listen on '127.0.0.1', preventing access from other machines. This PR changes this to '0.0.0.0'. Without this, calling every handler across a set of servers requires installation and remote execution of a script that can call the local handlers. It's much cleaner to do this via a server+port URL. You do however still need to do remote calls to `passenger-status` to determine the ports, but a list of these ports can be efficiently maintained through `attached_process` and `detached_process` hooks.

The password header prevents remote access to the handlers being a security concern, and firewalls can anyway be set to only let in legitimate requests.

Finally, a [comment](/phusion/passenger/blob/stable-6.0/src/ruby_supportlib/phusion_passenger/request_handler.rb#L313) about the server address said 

> We use "127.0.0.1" as address in order to force TCPv4 instead of TCPv6.

I don't understand why this was done, so I left the address forced to IPv4.

