### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/passenger.gemspec
+++ b/passenger.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.summary = "A fast and robust web server and application server for Ruby, Python and Node.js"
   s.name = PhusionPassenger::PACKAGE_NAME
   s.version = PhusionPassenger::VERSION_STRING
-  s.rubyforge_project = "passenger"
   s.author = "Phusion - http://www.phusion.nl/"
   s.email = "software-signing@phusion.nl"
   s.require_paths = ["src/ruby_supportlib"]


### PR DESCRIPTION
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.