### PR TITLE
Use UNIX socket for HTTP socket in the same way as server sockets

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/request_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/request_handler.rb
@@ -109,7 +109,12 @@ module PhusionPassenger
         :accept_http_requests => true
       }
 
-      @http_socket_address, @http_socket = create_tcp_socket
+      if should_use_unix_sockets?
+        @http_socket_address, @http_socket = create_unix_socket_on_filesystem(options)
+      else
+        @http_socket_address, @http_socket = create_tcp_socket
+      end
+
       @server_sockets[:http] = {
         :address     => @http_socket_address,
         :socket      => @http_socket,


### PR DESCRIPTION
This PR unifies the way sockets are created for both Server and HTTP sockets.

When TCP sockets are used exclusively for HTTP sockets, it significantly weakens our security stance in the shared hosting space as we cannot control which TCP ports are chosen (the next available ephemeral port is chosen by the kernel); this makes it difficult for us to limit access to this port.

See lines 99-103 for reference