### PR TITLE
support Rack::BodyProxy chunked responses

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
@@ -166,7 +166,7 @@ module PhusionPassenger
         # Fix up incompliant body objects. Ensure that the body object
         # can respond to #each.
         output_body = should_output_body?(status, is_head_request)
-        if body.is_a?(String) || body.nil? || output_body
+        if body.is_a?(String)
           body = [body]
         elsif body.nil?
           body = []

--- a/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
@@ -219,7 +219,7 @@ module PhusionPassenger
               @can_keepalive = false
             else
               body_size = 0
-              body.each { |part| body_size += bytesize(part) }
+              body.to_a.each { |part| body_size += bytesize(part) }
               if body_size != content_length
                 raise "Response body size doesn't match Content-Length header: #{body_size} vs #{content_length}"
               end
@@ -249,7 +249,7 @@ module PhusionPassenger
           if body.is_a?(Array)
             message_length_type = :content_length
             content_length = 0
-            body.each { |part| content_length += bytesize(part.to_s) }
+            body.to_a.each { |part| content_length += bytesize(part.to_s) }
 
             headers_output << CONTENT_LENGTH_HEADER_AND_SEPARATOR
             headers_output << content_length.to_s
@@ -279,18 +279,18 @@ module PhusionPassenger
               connection.writev2(headers_output, body)
             else
               connection.writev(headers_output)
-              body.each do |part|
+              body.to_a.each do |part|
                 connection.write(part.to_s)
               end
             end
           when :chunked_by_app
             connection.writev(headers_output)
-            body.each do |part|
+            body.to_a.each do |part|
               connection.write(part.to_s)
             end
           when :needs_chunking
             connection.writev(headers_output)
-            body.each do |part|
+            body.to_a.each do |part|
               size = bytesize(part.to_s)
               if size != 0
                 connection.writev(chunk_data(part.to_s, size))

--- a/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
@@ -166,7 +166,7 @@ module PhusionPassenger
         # Fix up incompliant body objects. Ensure that the body object
         # can respond to #each.
         output_body = should_output_body?(status, is_head_request)
-        if body.is_a?(String)
+        if body.is_a?(String) || (defined?(Rack) && body.is_a?(Rack::BodyProxy))
           body = [body]
         elsif body.nil?
           body = []
@@ -219,7 +219,7 @@ module PhusionPassenger
               @can_keepalive = false
             else
               body_size = 0
-              Array(body).each { |part| body_size += bytesize(part) }
+              body.each { |part| body_size += bytesize(part) }
               if body_size != content_length
                 raise "Response body size doesn't match Content-Length header: #{body_size} vs #{content_length}"
               end
@@ -249,7 +249,7 @@ module PhusionPassenger
           if body.is_a?(Array)
             message_length_type = :content_length
             content_length = 0
-            Array(body).each { |part| content_length += bytesize(part.to_s) }
+            body.each { |part| content_length += bytesize(part.to_s) }
 
             headers_output << CONTENT_LENGTH_HEADER_AND_SEPARATOR
             headers_output << content_length.to_s
@@ -279,18 +279,18 @@ module PhusionPassenger
               connection.writev2(headers_output, body)
             else
               connection.writev(headers_output)
-              Array(body).each do |part|
+              body.each do |part|
                 connection.write(part.to_s)
               end
             end
           when :chunked_by_app
             connection.writev(headers_output)
-            Array(body).each do |part|
+            body.each do |part|
               connection.write(part.to_s)
             end
           when :needs_chunking
             connection.writev(headers_output)
-            Array(body).each do |part|
+            body.each do |part|
               size = bytesize(part.to_s)
               if size != 0
                 connection.writev(chunk_data(part.to_s, size))


### PR DESCRIPTION
Currently there is a check to see if body is a string and if so wrap it in an array:
```
if body.is_a?(String)
    body = [body]
```
Rack wraps the body in a `Rack::BodyProxy` object which delegates many methods to a String but doesn't pass that type check.  Eventually passenger will try to loop over the body using the `each` method with is not defined on strings. This crashes the thread with errors such as

```
App 21418 output: [ 2020-04-28 13:36:01.0751 21418/0x000055b6fa5901a8(Worker 1) utils.rb ]: *** Exception NoMethodError in Rack response body object (undefined method `each' for "":String) (process 21418, thread 0x000055b6fa5901a8(Worker 1)):
App 21418 output:       from /app/shared/bundle/ruby/2.5.0/gems/rack-2.2.2/lib/rack/body_proxy.rb:41:in `method_missing'
App 21418 output:       from /app/shared/bundle/ruby/2.5.0/gems/rack-2.2.2/lib/rack/body_proxy.rb:41:in `method_missing'
App 21418 output:       from /app/shared/bundle/ruby/2.5.0/gems/rack-2.2.2/lib/rack/body_proxy.rb:41:in `method_missing'
App 21418 output:       from /app/shared/bundle/ruby/2.5.0/gems/rack-2.2.2/lib/rack/body_proxy.rb:41:in `method_missing'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:277:in `process_body'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:129:in `process_request'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:134:in `accept_and_process_next_request'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:95:in `main_loop'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler.rb:439:in `block (3 levels) in start_threads'
App 21418 output:       from /usr/lib/ruby/vendor_ruby/phusion_passenger/utils.rb:97:in `block in create_thread_and_abort_on_exception'
[ W 2020-04-28 13:36:01.0753 6216/Ti Ser/Server.h:1063 ]: [Client 6-75901] Disconnecting client with error: error parsing app response chunked encoding: unexpected end-of-stream
```