### PR TITLE
Match static rails assets on 8-digit content hash

### DIFF
--- a/resources/templates/standalone/rails_asset_pipeline.erb
+++ b/resources/templates/standalone/rails_asset_pipeline.erb
@@ -1,5 +1,5 @@
 # Rails asset pipeline & webpacker support.
-location ~ "^/(assets|packs)/.+-([0-9a-f]{32}|[0-9a-f]{64}|[0-9a-f]{20})\..+" {
+location ~ "^/(assets|packs)/.+-([0-9a-f]{32}|[0-9a-f]{64}|[0-9a-f]{20}|[0-9a-f]{8})\..+" {
     error_page 490 = @static_asset;
     error_page 491 = @dynamic_request;
     recursive_error_pages on;


### PR DESCRIPTION
The default implementation of a rails installation with webpacker stylesheets uses an 8-digit content hash for fingerprinting CSS and other assets.  This prevents the current rails_asset_pipeline configuration for passenger standalone for recognizing these assets as static assets.

To resolve, we can simply add the 8-digit length variation of the filename to the location match:
`location ~ "^/(assets|packs)/.+-([0-9a-f]{32}|[0-9a-f]{64}|[0-9a-f]{20}|[0-9a-f]{8})\..+" {`

https://github.com/rails/webpacker/blob/d099e066931b14277726fe83339332ddd25a50ab/package/environments/base.js#L39