### PR TITLE
Fix crash on Amazon Linux 2

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/common_library.rb
+++ b/src/ruby_supportlib/phusion_passenger/common_library.rb
@@ -304,6 +304,8 @@ COMMON_LIBRARY = CommonLibraryBuilder.new do
     :category => :base,
     # Compiling with -O3 causes segfaults on RHEL 6
     :optimize => :heavy,
+    # Compiling with SSE2 causes segfaults on Amazon Linux 2
+    :cflags => ' -mno-sse2',
     :strict_aliasing => false
   define_component 'IOTools/IOUtils.o',
     :source   => 'IOTools/IOUtils.cpp',

--- a/src/ruby_supportlib/phusion_passenger/common_library.rb
+++ b/src/ruby_supportlib/phusion_passenger/common_library.rb
@@ -305,7 +305,7 @@ COMMON_LIBRARY = CommonLibraryBuilder.new do
     # Compiling with -O3 causes segfaults on RHEL 6
     :optimize => :heavy,
     # Compiling with SSE2 causes segfaults on Amazon Linux 2
-    :cflags => ' -mno-sse2',
+    :cflags => RbConfig::CONFIG['host_cpu'] == 'x86_64' ? ' -mno-sse2' : '',
     :strict_aliasing => false
   define_component 'IOTools/IOUtils.o',
     :source   => 'IOTools/IOUtils.cpp',


### PR DESCRIPTION
gcc version 7.3.1 20180712 (Red Hat 7.3.1-6)
#2234