### PR TITLE
HTTP 418 now conforms with RFC 2324

### DIFF
--- a/src/cxx_supportlib/Utils/HttpConstants.h
+++ b/src/cxx_supportlib/Utils/HttpConstants.h
@@ -114,7 +114,7 @@ getStatusCodeAndReasonPhrase(int statusCode) {
 	case 417:
 		return "417 Expectation Failed";
 	case 418:
-		return "418 Not A Funny April Fools Joke";
+		return "418 I'm A Teapot";
 	case 420:
 		// https://dev.twitter.com/docs/error-codes-responses
 		return "420 Enhance Your Calm";


### PR DESCRIPTION
Who judges whether a april's fools is funny or not?
see
https://tools.ietf.org/html/rfc7168#section-2.3.3