### PR TITLE
nginx module: avoid using other modules directories

### DIFF
--- a/src/nginx_module/Configuration.c
+++ b/src/nginx_module/Configuration.c
@@ -61,8 +61,8 @@ static ngx_str_t headers_to_hide[] = {
 
 passenger_main_conf_t passenger_main_conf;
 
-static ngx_path_init_t  ngx_http_proxy_temp_path = {
-    ngx_string(NGX_HTTP_PROXY_TEMP_PATH), { 1, 2, 0 }
+static ngx_path_init_t  ngx_http_passenger_temp_path = {
+    ngx_string(NGX_HTTP_PASSENGER_TEMP_PATH), { 1, 2, 0 }
 };
 
 
@@ -580,7 +580,7 @@ passenger_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf,
                               &conf->upstream_config.temp_path,
                               prev->upstream_config.temp_path,
-                              &ngx_http_proxy_temp_path)
+                              &ngx_http_passenger_temp_path)
         != NGX_OK)
     {
         return NGX_CONF_ERROR;

--- a/src/nginx_module/config
+++ b/src/nginx_module/config
@@ -123,6 +123,8 @@ nginx_micro_version=`echo "$nginx_version" | cut -d . -f 3`
 have=PASSENGER_NGINX_MICRO_VERSION value="$nginx_micro_version"
 . auto/define
 
+have=NGX_HTTP_PASSENGER_TEMP_PATH value="\"passenger_temp\""
+. auto/define
 
 ngx_addon_name=ngx_http_passenger_module
 


### PR DESCRIPTION
This patch introduces a default value for `passenger_temp_path` option. This value is unique for passenger module.

The problem exists for several years. It could be ignored until https://github.com/phusion/passenger/commit/3fef0f2c8b67899a5b38600b86f6390c4a81846d which added a check of `ngx_conf_merge_path_value` return value.

To reproduce initial problem, you have to create an nginx configuration with `proxy_temp_path "proxy_temp";` line and passenger module loaded. No passenger configuration required. The value ("proxy_temp") should match complied-in default value for `proxy_temp_path`.
In this configuration nginx native proxy module will use it's own directory and then passenger module will try to add the same directory into configuration. The configuration will fail with an [emerg] message like
```
[emerg] : the path name "/etc/nginx/proxy_temp" in /etc/nginx/nginx.conf:40 has the same name as default path, but the different levels, you need to define default path in http section
```
Which is quite cryptic to me.
You can run into the same problem if you use `passenger_temp_path` default value for `proxy_temp_path` (`proxy_temp_pass "passenger_temp";`) with this patch applied. But this is definitely a configuration problem and much easier to diagnose.

Let me know if I'm missing anything here.

Regards,
oxpa
