### PR TITLE
Format 501/502 responses based on the request format

### DIFF
--- a/src/agent/Core/Controller.h
+++ b/src/agent/Core/Controller.h
@@ -313,6 +313,8 @@ private:
 		Request **req);
 	void endRequestWithAppSocketReadError(Client **client, Request **req,
 		int e);
+	ServerKit::HeaderTable getHeadersWithContentType(Request *req);
+	const StaticString getFormattedMessage(Request *req, const StaticString &body);
 	void endRequestWithSimpleResponse(Client **c, Request **r,
 		const StaticString &body, int code = 200);
 	void endRequestAsBadGateway(Client **client, Request **req);


### PR DESCRIPTION
Closes #2278 by formatting the error responses in JSON/HTML formats based on the `content-type` header of the request.

I added 2 more methods to `InternalUtils.cpp` file.

`getHeadersWithContentType` returns the appropriate `content-type` header for the response, should be used for initializing any response headers.

`getFormattedMessage` returns the formatted error message based on the request's `content-type` header