### PR TITLE
raise the error in case of Errno::ENOBUFS

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb
@@ -106,6 +106,9 @@ module PhusionPassenger
           begin
             status, headers, body = @app.call(env)
           rescue => e
+            if e.is_a?(Errno::ENOBUFS)
+              raise e
+            end
             if !should_swallow_app_error?(e, socket_wrapper)
               # It's a good idea to catch application exceptions here because
               # otherwise maliciously crafted responses can crash the app,
@@ -155,6 +158,9 @@ module PhusionPassenger
             process_body(env, connection, socket_wrapper, status.to_i, is_head_request,
               headers, body)
           rescue => e
+            if e.is_a?(Errno::ENOBUFS)
+              raise e
+            end
             if !should_swallow_app_error?(e, socket_wrapper)
               print_exception("Rack response body object", e)
             end
@@ -324,6 +330,9 @@ module PhusionPassenger
         begin
           body.close if body && body.respond_to?(:close)
         rescue => e
+          if e.is_a?(Errno::ENOBUFS)
+            raise e
+          end
           if !should_swallow_app_error?(e, socket_wrapper)
             print_exception("Rack response body object's #close method", e)
           end


### PR DESCRIPTION
This has bitten us as Passenger did not have any buffer to return the response body. 
Our service still replied with 200 OK but with an empty response body, which got cached and started trickling down into several errors across the platform.

I think this specific exception should be caught as a memory error and thus not muted here.

Do you have a conflicting opinion? I want to hear all about it.

