### PR TITLE
Support mongoid

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/loader_shared_helpers.rb
+++ b/src/ruby_supportlib/phusion_passenger/loader_shared_helpers.rb
@@ -310,7 +310,7 @@ module PhusionPassenger
       end
 
       # If we were forked from a preloader process then clear or
-      # re-establish ActiveRecord database connections. This prevents
+      # re-establish ActiveRecord/Mongoid database connections. This prevents
       # child processes from concurrently accessing the same
       # database connection handles.
       if forked
@@ -324,6 +324,13 @@ module PhusionPassenger
             ActiveRecord::Base.establish_connection
           rescue
             DebugLogging.debug('ActiveRecord is not configured, start it yourself')
+          end
+        end
+
+        if defined?(Mongoid::Clients)
+          Mongoid::Clients.clients.each do |name, client|
+            client.close
+            client.reconnect
           end
         end
 


### PR DESCRIPTION
As stated within the `mongo-ruby-driver` [docs](https://github.com/mongodb/mongo-ruby-driver/blob/f9b46224e890bae11065c59139dd035869c2a305/docs/tutorials/ruby-driver-create-client.txt#L1412) It's recommended to reconnect the mongo connections within the child processes.

This PR will make `mongoid` works out of the box with passenger, like ActiveRecord.