### PR TITLE
Error while installing in ubuntu arm based processor

### DIFF
--- a/request
+++ b/request
@@ -1,0 +1,1 @@
+I am unable to install passenger on ubuntu server which is running on ARM based processor. Can you help?


### PR DESCRIPTION
First of all excuse me for creating this pull request only for this query, but i could not find any other way to reach you folks.
I am stuck while installing passenger binary on ubuntu which is created on arm based architecture. 

1-Ubuntu SMP Tue Apr 13 16:00:48 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux

i get the following error while trying to install..
 Skipping acquire of configured file 'main/binary-arm64/Packages' as repository 'https://oss-binaries.phusionpassenger.com/apt/passenger bionic InRelease' doesn't support architecture 'arm64'