### PR TITLE
fix(nodejs): allow usage of ESM + CommonJS modules

### DIFF
--- a/src/helper-scripts/node-loader.js
+++ b/src/helper-scripts/node-loader.js
@@ -30,6 +30,7 @@ var os = require('os');
 var fs = require('fs');
 var http = require('http');
 var util = require('util');
+var childProcess = require('child_process')
 
 var nodeClusterErrCount = 0;
 var meteorClusterErrCount = 0;
@@ -240,7 +241,7 @@ function configure(_options) {
 function loadApplication() {
 	var appRoot = PhusionPassenger.options.app_root || process.cwd();
 	var startupFile = PhusionPassenger.options.startup_file || (appRoot + '/' + 'app.js');
-	require(startupFile);
+	childProcess.fork(startupFile);
 }
 
 function extractCallback(args) {


### PR DESCRIPTION
Hey! :wave: 

Currently, we can't use the new ESM syntax to import modules in [Node.js](https://nodejs.org/), if we do we get that error : 
```
App 367 output: internal/modules/cjs/loader.js:926
App 367 output:     throw new ERR_REQUIRE_ESM(filename);
App 367 output:     ^
App 367 output: Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/luth3658/app/ludwig-google-actions/index.mjs
App 367 output:     at Module.load (internal/modules/cjs/loader.js:926:11)
App 367 output:     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
App 367 output:     at Module.require (internal/modules/cjs/loader.js:952:19)
App 367 output:     at Module.require (/opt/cpanel/ea-ruby27/root/usr/share/passenger/helper-scripts/node-loader.js:80:25)
App 367 output:     at require (internal/modules/cjs/helpers.js:88:18)
App 367 output:     at loadApplication (/opt/cpanel/ea-ruby27/root/usr/share/passenger/helper-scripts/node-loader.js:243:2)
App 367 output:     at setupEnvironment (/opt/cpanel/ea-ruby27/root/usr/share/passenger/helper-scripts/node-loader.js:214:2)
App 367 output:     at Object.<anonymous> (/opt/cpanel/ea-ruby27/root/usr/share/passenger/helper-scripts/node-loader.js:133:1)
App 367 output:     at Module._compile (internal/modules/cjs/loader.js:1063:30)
App 367 output:     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10) {
App 367 output:   code: 'ERR_REQUIRE_ESM'
App 367 output: }
```

That's because, inside the `loadApplication` function in `src/helper-scripts/node-loader.js`, we use `require` to start the application, instead, we should use `childProcess.fork` so we can support both CommonJS and ESM imports not only CommonJS as it is currently the case, it should not break existing applications and older Node.js versions, as you can see in the documentation, it is supported since Node.js v0.5.0 (see: https://nodejs.org/dist/latest-v16.x/docs/api/child_process.html#child_process_child_process_fork_modulepath_args_options).

With the changes of this PR, we would be able to use the `import` syntax instead of `require` in Node.js v12 or newer and as said it would not impact older versions of Node.js using the `require` syntax.