### PR TITLE
Fix os_version parser for CentOS Stream 8

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/platform_info/operating_system.rb
+++ b/src/ruby_supportlib/phusion_passenger/platform_info/operating_system.rb
@@ -87,7 +87,7 @@ module PhusionPassenger
         data = read_file('/etc/centos-release')
         data = read_file('/etc/redhat-release') if data.empty?
         if !data.empty?
-          data =~ /^(.+?) (Linux )?(release |version )?(.+?)( |$)/i
+          data =~ /^(.+?) (Linux |Stream )?(release |version )?(.+?)( |$)/i
           return VersionComparer.new($4) if $4
         end
 


### PR DESCRIPTION
It fixed that OS Version parser is unexpected working on CentOS Stream 8.

fix: #2377