### PR TITLE
Fixed openssl_extra_ldflags path for macOS with Apple Silicon

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/platform_info/openssl.rb
+++ b/src/ruby_supportlib/phusion_passenger/platform_info/openssl.rb
@@ -57,7 +57,7 @@ module PhusionPassenger
         elsif File.exist?("/usr/local/opt/openssl/include")
           "-L/usr/local/opt/openssl/lib"
         elsif File.exist?("/opt/homebrew/opt/openssl/include")
-          "-L/opt/homebrew/opt/openssl/include"
+          "-L/opt/homebrew/opt/openssl/lib"
         else
           "-L/opt/local/lib"
         end


### PR DESCRIPTION
It fixed openssl_extra_ldflags path for macos with apple silicon.

fix: #2389

### Related PR
- #2330 