### PR TITLE
patch winston to suppress padLevels warning

### DIFF
--- a/src/nodejs_supportlib/vendor-copy/winston/lib/winston/transports/http.js
+++ b/src/nodejs_supportlib/vendor-copy/winston/lib/winston/transports/http.js
@@ -69,7 +69,9 @@ Http.prototype._request = function (options, callback) {
     res.resume();
   });
 
-  req.end(new Buffer(JSON.stringify(options), 'utf8'));
+  // Use Buffer.alloc and Buffer.from instead of new Buffer
+  // @see https://github.com/winstonjs/winston/pull/1281
+  req.end(Buffer.from(JSON.stringify(options), 'utf8'));
 };
 
 //
@@ -180,7 +182,7 @@ Http.prototype.query = function (options, callback) {
 //
 Http.prototype.stream = function (options) {
   options = options || {};
-  
+
   var self = this,
       stream = new Stream,
       req,


### PR DESCRIPTION
See [#winstonjs/winston/issues/1882](https://github.com/winstonjs/winston/issues/1882)

This is a fix for #2341 

There are other few changes necessary to keep winston up to date with it's version `2.4.5`.

Hope this helps :)

Edit: 
I've already signed contributor agreement!

cc @CamJN