### PR TITLE
Restore ability to build against upstream libev

### DIFF
--- a/build/common_library.rb
+++ b/build/common_library.rb
@@ -110,6 +110,7 @@ if USE_VENDORED_LIBEV
     result = '-Isrc/cxx_supportlib/vendor-modified/libev'
     # Apple Clang 4.2 complains about ambiguous member templates in ev++.h.
     result << ' -Wno-ambiguous-member-template' if PlatformInfo.compiler_supports_wno_ambiguous_member_template?
+    result << '-DUSE_VENDORED_LIBEV'
     result
   end
 

--- a/src/cxx_supportlib/BackgroundEventLoop.cpp
+++ b/src/cxx_supportlib/BackgroundEventLoop.cpp
@@ -269,11 +269,15 @@ BackgroundEventLoop::BackgroundEventLoop(bool scalable, bool usesLibuv)
 		throw RuntimeException("Cannot create a libev event loop");
 	}
 
+	#ifdef USE_VENDORED_LIBEV
 	P_LOG_FILE_DESCRIPTOR_OPEN2(ev_backend_fd(libev_loop), "libev event loop: backend FD");
+	#endif
 
 	ev_async_init(&priv->exitSignaller, signalLibevExit);
+	#ifdef USE_VENDORED_LIBEV
 	P_LOG_FILE_DESCRIPTOR_OPEN2(ev_loop_get_pipe(libev_loop, 0), "libev event loop: async pipe 0");
 	P_LOG_FILE_DESCRIPTOR_OPEN2(ev_loop_get_pipe(libev_loop, 1), "libev event loop: async pipe 1");
+	#endif
 	priv->exitSignaller.data = this;
 	safe = boost::make_shared<SafeLibev>(libev_loop);
 

--- a/src/cxx_supportlib/SafeLibev.h
+++ b/src/cxx_supportlib/SafeLibev.h
@@ -147,9 +147,11 @@ public:
 
 	~SafeLibev() {
 		destroy();
+		#ifdef USE_VENDORED_LIBEV
 		P_LOG_FILE_DESCRIPTOR_CLOSE(ev_loop_get_pipe(loop, 0));
 		P_LOG_FILE_DESCRIPTOR_CLOSE(ev_loop_get_pipe(loop, 1));
 		P_LOG_FILE_DESCRIPTOR_CLOSE(ev_backend_fd(loop));
+		#endif
 		ev_loop_destroy(loop);
 	}
 


### PR DESCRIPTION
Make the usage of the local changes to libev only apply if using the
vendored version.

Fixes: https://github.com/phusion/passenger/issues/1544