### PR TITLE
Add a PASSENGER_MAX_LOG_LINE_BYTES option increase the number of characters allowed per log line

### DIFF
--- a/src/agent/Core/SpawningKit/PipeWatcher.h
+++ b/src/agent/Core/SpawningKit/PipeWatcher.h
@@ -90,7 +90,8 @@ private:
 
 		UPDATE_TRACE_POINT();
 		while (!boost::this_thread::interruption_requested()) {
-			char buf[1024 * 8];
+			int log_line_length = (getenv("PASSENGER_MAX_LOG_LINE_LENGTH_BYTES") == null) ? 1024 * 8 : getenv("PASSENGER_MAX_LOG_LINE_LENGTH_BYTES")
+			char buf[log_line_length];
 			ssize_t ret;
 
 			UPDATE_TRACE_POINT();


### PR DESCRIPTION
An attempt to resolve https://github.com/phusion/passenger/issues/2413

My particular issue with Passenger splitting logs into multiple lines is that we use Filebeat to pipe logs to Logstash, and Logstash expects our Rails logging to be in `json` format. In cases where we have long stack traces, these multiline logs end up not being parsed correctly (with a `_jsonparsefailure` on the Logstash side). Whilst there are multiline configurations available for both Filebeat and Logstash, it's [recommended](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html) to use mulitline configs in Filebeat over Logstash. However, since Passenger  appends `App #{pid} output:` to each of the log lines, it means we'd need to strip out the extra text before stitching logs together. Whilst I also know the latest version of passenger contains the option to remove the `App #{pid} output:` prefix, it feels a bit simpler to just be able to configure Passenger to log larger contents into a single line without breaking it up.

I tried looking at previous pull requests to figure out whether there's anywhere I would need to add this to the documentation, but couldn't find anything. Happy to add it if I'm pointed in the right direction.

Any feedback would be great! Thanks :) 