### PR TITLE
Use closefrom on FreeBSD 8+

### DIFF
--- a/src/cxx_supportlib/ProcessManagement/Utils.cpp
+++ b/src/cxx_supportlib/ProcessManagement/Utils.cpp
@@ -52,7 +52,7 @@
 #include <ProcessManagement/Utils.h>
 #include <Utils/AsyncSignalSafeUtils.h>
 
-#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun)
+#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun) || (defined(__FreeBSD__) && defined(__FreeBSD_version) && __FreeBSD_version >= 800000)
 	// Introduced in Solaris 9. Let's hope nobody actually uses
 	// a version that doesn't support this.
 	#define HAS_CLOSEFROM


### PR DESCRIPTION
Fix for #2115 and #2190.

`closefrom` is supported from `FreeBSD 8.0`, released in 2009 so I don't know if it is nessesary to check `__FreeBSD_version`.
Using `closefrom` speedups the application startup about ten times: from ~3 sec to ~0.3 sec and reduces CPU usage.