### PR TITLE
Update native_support.rb to allow load_native_extension handle invalid byte sequences

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/native_support.rb
+++ b/src/ruby_supportlib/phusion_passenger/native_support.rb
@@ -427,10 +427,12 @@ module PhusionPassenger
         require(name_or_filename)
         return defined?(PhusionPassenger::NativeSupport)
       rescue LoadError => e
-        if e.to_s =~ /dlopen/
+        s = e.to_s
+        s = s.encode("US-ASCII", :invalid => :replace) if s.respond_to?(:encode)
+        if s =~ /dlopen/
           # Print dlopen failures. We're not interested in any other
           # kinds of failures, such as file-not-found.
-          puts e.to_s.gsub(/^/, "     ")
+          puts s.gsub(/^/, "     ")
         end
         return false
       end


### PR DESCRIPTION
We have been getting the following errors from passenger-6.0.17 via RPM from the Passenger REPO on CentOS7 :

```
App 6968 output: /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:430:in `rescue in load_native_extension': invalid byte sequence in US-ASCII (ArgumentError)
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:426:in `load_native_extension'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:113:in `load_from_load_path'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:40:in `try_load'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:50:in `start'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:443:in `<top (required)>'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger.rb:243:in `require_passenger_lib'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/preloader_shared_helpers.rb:29:in `<top (required)>'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger.rb:243:in `require_passenger_lib'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:57:in `init_passenger'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:183:in `<module:App>'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:30:in `<module:PhusionPassenger>'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:29:in `<main>'
App 6968 output: <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require': linked to incompatible @<D2><EA>^A - /usr/lib64/ruby/vendor_ruby/passenger_native_support.so (LoadError)
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:427:in `load_native_extension'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:113:in `load_from_load_path'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:40:in `try_load'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:50:in `start'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/native_support.rb:443:in `<top (required)>'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger.rb:243:in `require_passenger_lib'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger/preloader_shared_helpers.rb:29:in `<top (required)>'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
App 6968 output:        from /usr/share/ruby/vendor_ruby/phusion_passenger.rb:243:in `require_passenger_lib'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:57:in `init_passenger'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:183:in `<module:App>'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:30:in `<module:PhusionPassenger>'
App 6968 output:        from /usr/share/passenger/helper-scripts/rack-preloader.rb:29:in `<main>'
[ E 2023-03-16 11:49:12.1538 6714/Tz age/Cor/App/Implementation.cpp:221 ]: Could not spawn process for application /var/www/epro-project5-testing.elysium-ltd.net: The application process exited prematurely.
  Error ID: 80aaf344
  Error details saved to: /tmp/passenger-error-mpkRcW.html
```

The /usr/lib64/ruby/vendor_ruby/passenger_native_support.so in the RPM is correctly linked to ruby-2.0, but we are using a custom ruby-3.2.1 so the cause of the exception is correct.

Eventually the exception doesn't have any invalid byte sequences in it and passenger starts the application normally and carries on normally until the next web server (Apache) restart.  This is random though.

This is caused by the LoadError exception having invalid byte sequences in its message, I have patched the rescue to replace the invalid byte sequences on versions of ruby that support 'String.encode'.  I have tested this on all versions of ruby from 1.8.7 to 3.2.1.

This is the exception on ruby-3.1.3
```
irb(main):001:0> require '/usr/lib64/ruby/vendor_ruby/passenger_native_support.so'
<internal:/usr/lib64/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': incompatible library version - /usr/lib64/ruby/vendor_ruby/passenger_native_support.so (LoadError)
	from <internal:/usr/lib64/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from (irb):1:in `<main>'
	from /usr/lib64/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
	from /usr/bin/irb31:25:in `load'
	from /usr/bin/irb31:25:in `<main>'
```

This is the exception on ruby-3.2.1
```
irb(main):001:0> require '/usr/lib64/ruby/vendor_ruby/passenger_native_support.so'
<internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require': linked to incompatible \xC1- /usr/lib64/ruby/vendor_ruby/passenger_native_support.so (LoadError)
	from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from (irb):1:in `<main>'
	from /usr/lib64/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
	from /usr/bin/irb32:25:in `load'
	from /usr/bin/irb32:25:in `<main>'
```

So, it looks like only ruby-3.2.x could possibly generate an invalid byte sequence.
