### PR TITLE
add unhandled_exception_before_exit event callback for ruby

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/public_api.rb
+++ b/src/ruby_supportlib/phusion_passenger/public_api.rb
@@ -30,6 +30,7 @@ module PhusionPassenger
     @@event_credentials = []
     @@event_after_installing_signal_handlers = []
     @@event_oob_work = []
+    @@event_unhandled_exception_before_exit = []
     @@advertised_concurrency_level = nil
 
     def on_event(name, &block)
@@ -69,6 +70,8 @@ module PhusionPassenger
         @@event_after_installing_signal_handlers
       when :oob_work
         @@event_oob_work
+      when :unhandled_exception_before_exit
+        @@event_unhandled_exception_before_exit
       else
         raise ArgumentError, "Unknown event name '#{name}'"
       end

--- a/src/ruby_supportlib/phusion_passenger/utils.rb
+++ b/src/ruby_supportlib/phusion_passenger/utils.rb
@@ -115,6 +115,7 @@ module PhusionPassenger
           raise
         rescue Exception => e
           print_exception(nil, e)
+          PhusionPassenger.call_event(:unhandled_exception_before_exit, e)
           exit(1)
         end
       end


### PR DESCRIPTION
Adds a callback for application code to do last-chance logging etc... when an unhandled exception is caught and `at_exit` handling is not possible per https://github.com/phusion/passenger/issues/2481
