### PR TITLE
Rescue any `EncodingError` while handling native support lib `LoadError`

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/native_support.rb
+++ b/src/ruby_supportlib/phusion_passenger/native_support.rb
@@ -427,12 +427,15 @@ module PhusionPassenger
         require(name_or_filename)
         return defined?(PhusionPassenger::NativeSupport)
       rescue LoadError => e
-        s = e.to_s
-        s = s.encode("US-ASCII", :invalid => :replace) if s.respond_to?(:encode)
-        if s =~ /dlopen/
-          # Print dlopen failures. We're not interested in any other
-          # kinds of failures, such as file-not-found.
-          puts s.gsub(/^/, "     ")
+        begin
+          s = e.to_s
+          s = s.encode("US-ASCII", :invalid => :replace) if s.respond_to?(:encode)
+          if s =~ /dlopen/
+            # Print dlopen failures. We're not interested in any other
+            # kinds of failures, such as file-not-found.
+            puts s.gsub(/^/, "     ")
+          end
+        rescue EncodingError
         end
         return false
       end


### PR DESCRIPTION
In 6.0.18 we started to try to encode the error string into ASCII before checking it for `dlopen`. This was done to try to handle invalid byte sequences caused by a bug in Ruby that's been fixed in Ruby 3.3.

I've encountered a similar issue to the author and this fix hasn't fixed it. Instead, I now receive an `Encoding::UndefinedConversionError` which isn't handled. I've decided to wrap the whole error-handling logic with a rescue around `EncodingError` but I'm open to using `StandardError` here - we're trying to handle an exception and be nice to Passenger users but ultimately we do not want the failure to load this extension to cause application errors and it currently does.

Follow up to https://github.com/phusion/passenger/pull/2479
Fixes https://github.com/phusion/passenger/issues/2513