### PR TITLE
Fix wsgi-loader.py incompatibility with python 3.3 and 3.4

### DIFF
--- a/src/helper-scripts/wsgi-loader.py
+++ b/src/helper-scripts/wsgi-loader.py
@@ -25,7 +25,7 @@
 
 import sys, os, threading, signal, traceback, socket, select, struct, logging, errno
 import tempfile, json, time
-if sys.version_info[0] >= 3:
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
 	from importlib import util
 else:
 	import imp
@@ -80,7 +80,7 @@ def load_app():
 
 	sys.path.insert(0, os.getcwd())
 	startup_file = options.get('startup_file', 'passenger_wsgi.py')
-	if sys.version_info[0] >= 3:
+	if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
 		spec = util.spec_from_file_location("passenger_wsgi", startup_file)
 		assert spec is not None
 		app_module = util.module_from_spec(spec)


### PR DESCRIPTION
After https://github.com/phusion/passenger/pull/2502  wsgi-loader.py is incompatible with python3.3 and python 3.4. An error `AttributeError: 'module' object has no attribute 'spec_from_file_location'` is thrown.

```python
$ python3
Python 3.4.10 (default, Oct  4 2023, 09:14:39) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib.util
>>> importlib.util.module_from_spec
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'module_from_spec'
```

`spec_from_file_location` was added in [python3.5](https://docs.python.org/3/whatsnew/3.5.html#importlib). I restored compatibility by making use `spec_from_file_location` on python3.5+.

`imp` module was removed in [python3.12](https://docs.python.org/3/whatsnew/3.12.html#imp).