### PR TITLE
Fix upstream_config.limit_rate initialization for Nginx 1.27.0 compatibility

### DIFF
--- a/src/nginx_module/Configuration.c
+++ b/src/nginx_module/Configuration.c
@@ -224,7 +224,9 @@ passenger_create_loc_conf(ngx_conf_t *cf)
 
     conf->upstream_config.send_lowat = NGX_CONF_UNSET_SIZE;
     conf->upstream_config.buffer_size = NGX_CONF_UNSET_SIZE;
-    #if NGINX_VERSION_NUM >= 1007007
+    #if NGINX_VERSION_NUM >= 1027000
+        conf->upstream_config.limit_rate = NGX_CONF_UNSET_PTR;
+    #elif NGINX_VERSION_NUM >= 1007007
         conf->upstream_config.limit_rate = NGX_CONF_UNSET_SIZE;
     #endif
 

--- a/src/nginx_module/Configuration.c
+++ b/src/nginx_module/Configuration.c
@@ -225,9 +225,11 @@ passenger_create_loc_conf(ngx_conf_t *cf)
     conf->upstream_config.send_lowat = NGX_CONF_UNSET_SIZE;
     conf->upstream_config.buffer_size = NGX_CONF_UNSET_SIZE;
     #if NGINX_VERSION_NUM >= 1027000
-        conf->upstream_config.limit_rate = NGX_CONF_UNSET_PTR;
+        ngx_conf_merge_ptr_value(conf->upstream_config.limit_rate,
+                                 prev->upstream_config.limit_rate, NULL);
     #elif NGINX_VERSION_NUM >= 1007007
-        conf->upstream_config.limit_rate = NGX_CONF_UNSET_SIZE;
+        ngx_conf_merge_size_value(conf->upstream_config.limit_rate,
+                                  prev->upstream_config.limit_rate, 0);
     #endif
 
     conf->upstream_config.busy_buffers_size_conf = NGX_CONF_UNSET_SIZE;


### PR DESCRIPTION
seeing some regression build failure when building against nginx 1.27.0

```
/private/tmp/passenger-20240529-10206-38vspk/passenger-6.0.22/src/nginx_module/Configuration.c:228:42: error: incompatible integer to pointer conversion assigning to 'ngx_http_complex_value_t *' from 'size_t' (aka 'unsigned long') [-Wint-conversion]
conf->upstream_config.limit_rate = NGX_CONF_UNSET_SIZE;
```

full log ref, https://github.com/Homebrew/homebrew-core/actions/runs/9291204641/job/25569305049?pr=173145

upstream commit ref, https://github.com/nginx/nginx/commit/71ca978a352e025151a78bfcedc0d64814b062cb

relates to https://github.com/Homebrew/homebrew-core/pull/173145



