### PR TITLE
fix passenger-install-nginx-module pcre2.h compile check

### DIFF
--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -576,7 +576,7 @@ private
             system("(gcc -I/usr/local/include -I/usr/include/pcre2 " <<
               "-I/usr/pkg/include -I/opt/local/include " <<
               "-I/opt/homebrew/include " <<
-              "-c passenger-check.c) >/dev/null 2>/dev/null")
+              "-DPCRE2_CODE_UNIT_WIDTH=8 -c passenger-check.c) >/dev/null 2>/dev/null")
           end
         ensure
           File.unlink("#{safe_tmpdir}/passenger-check.c") rescue nil

--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -576,7 +576,8 @@ private
             system("(gcc -I/usr/local/include -I/usr/include/pcre2 " <<
               "-I/usr/pkg/include -I/opt/local/include " <<
               "-I/opt/homebrew/include " <<
-              "-DPCRE2_CODE_UNIT_WIDTH=8 -c passenger-check.c) >/dev/null 2>/dev/null")
+              "-DPCRE2_CODE_UNIT_WIDTH=8 " <<
+              "-c passenger-check.c) >/dev/null 2>/dev/null")
           end
         ensure
           File.unlink("#{safe_tmpdir}/passenger-check.c") rescue nil


### PR DESCRIPTION
Hello.

pcre2.h requires the definition of PCRE2_CODE_UNIT_WIDTH.
The current code will always raise an error. The `pcre_is_installed?` method always returns false and always downloads pcre.tar.gz.

```text
/usr/include/pcre2.h:971:2: error: #error PCRE2_CODE_UNIT_WIDTH must be defined before including pcre2.h.
  971 | #error PCRE2_CODE_UNIT_WIDTH must be defined before including pcre2.h.
      |  ^~~~~
/usr/include/pcre2.h:972:2: error: #error Use 8, 16, or 32; or 0 for a multi-width application.
  972 | #error Use 8, 16, or 32; or 0 for a multi-width application.
      |  ^~~~~
```

NGINX code sets PCRE2_CODE_UNIT_WIDTH  to 8. https://github.com/nginx/nginx/blob/e734df6664e70f118ca3140bcef6d4f1750fa8fa/src/core/ngx_regex.h#L18