### PR TITLE
Add base64 as a dependency

### DIFF
--- a/passenger.gemspec
+++ b/passenger.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake', '>= 12.3.3'
   s.add_dependency 'rack', '>= 1.6.13'
   s.add_dependency 'rackup', '>= 2.0.0'
+  s.add_dependency 'base64', '>= 0.1.0'
   s.files = Dir[*PhusionPassenger::Packaging::GLOB] -
     Dir[*PhusionPassenger::Packaging::EXCLUDE_GLOB]
   s.executables = PhusionPassenger::Packaging::USER_EXECUTABLES +


### PR DESCRIPTION
Ruby 3.4 removes base64 as a default gem.
https://github.com/ruby/ruby/pull/9550