### PR TITLE
Fix clang 19 compilation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Release 6.0.25 (Not yet released)
 -------------
  * [Standalone] Changes Passenger (not app) start and stop timeouts to 25s (from 15s) except for Nginx engine mode, which retains a stop timeout of 60s.
+ * Fixes compilation with clang 19 (latest Fedora update) by dropping a buggy stddev function from the moving average header. Closes GH-2580.
  * 
 
 

--- a/src/cxx_supportlib/Algorithms/MovingAverage.h
+++ b/src/cxx_supportlib/Algorithms/MovingAverage.h
@@ -186,12 +186,6 @@ public:
 	double stddev() const {
 		return sqrt(sumOfSquaredData / dema.sumOfWeights - pow(average(), 2));
 	}
-
-	double stddev(unsigned long long now) const {
-		DiscExpMovingAverageWithStddev<alpha, alphaTimeUnit, maxAge> copy(*this);
-		copy.update(0, now);
-		return sqrt(copy.sumOfSquaredData / copy.sumOfWeights - pow(copy.average(), 2));
-	}
 };
 
 


### PR DESCRIPTION
By dropping unused code.

Fixes #2580.