### PR TITLE
Fix postcondition assertion error for old routing algorithm

### DIFF
--- a/src/agent/Core/ApplicationPool/Group/ProcessListManagement.cpp
+++ b/src/agent/Core/ApplicationPool/Group/ProcessListManagement.cpp
@@ -171,7 +171,7 @@ Group::findBestProcessPreferringStickySessionId(unsigned int id) const {
  *
  * If there is no process that can be routed to, then returns nullptr.
  *
- * @post result != nullptr || result.canBeRoutedTo()
+ * @post result == nullptr || result.canBeRoutedTo()
  */
 Process *
 Group::findBestProcess(const ProcessList &processes) const {

--- a/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp
+++ b/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp
@@ -78,7 +78,7 @@ Group::route(const Options &options) const {
 				if (process && process->canBeRoutedTo()) {
 					return RouteResult(process);
 				} else {
-					return RouteResult(NULL, true);
+					return RouteResult(NULL, process == nullptr);
 				}
 			}
 		} else {
@@ -116,7 +116,7 @@ Group::route(const Options &options) const {
 			if (process && process->canBeRoutedTo()) {
 				return RouteResult(process);
 			} else {
-				return RouteResult(NULL, true);
+				return RouteResult(NULL, process == nullptr);
 			}
 		}
 	}

--- a/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp
+++ b/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp
@@ -67,9 +67,44 @@ Group::route(const Options &options) const {
 		if (options.stickySessionId == 0) {
 			if (OXT_LIKELY(useNewRouting())) {
 				process = findBestProcess(enabledProcesses);
+				if (process != nullptr) {
+					assert(process->canBeRoutedTo());
+					return RouteResult(process);
+				} else {
+					return RouteResult(NULL, true);
+				}
             } else {
 				process = findEnabledProcessWithLowestBusyness();
+				if (process && process->canBeRoutedTo()) {
+					return RouteResult(process);
+				} else {
+					return RouteResult(NULL, true);
+				}
 			}
+		} else {
+			if (OXT_LIKELY(useNewRouting())) {
+				process = findBestProcessPreferringStickySessionId(options.stickySessionId);
+				if (process != nullptr) {
+					if (process->canBeRoutedTo()) {
+						return RouteResult(process);
+					} else {
+						return RouteResult(NULL, false);
+					}
+				} else {
+					return RouteResult(NULL, true);
+				}
+			}else{
+				process = findProcessWithStickySessionIdOrLowestBusyness(options.stickySessionId);
+				if (process && process->canBeRoutedTo()) {
+					return RouteResult(process);
+				} else {
+					return RouteResult(NULL, process == nullptr);
+				}
+			}
+		}
+	} else {
+		if (OXT_LIKELY(useNewRouting())) {
+			process = findBestProcess(disablingProcesses);
 			if (process != nullptr) {
 				assert(process->canBeRoutedTo());
 				return RouteResult(process);
@@ -77,32 +112,12 @@ Group::route(const Options &options) const {
 				return RouteResult(NULL, true);
 			}
 		} else {
-			if (OXT_LIKELY(useNewRouting())) {
-				process = findBestProcessPreferringStickySessionId(options.stickySessionId);
-			}else{
-				process = findProcessWithStickySessionIdOrLowestBusyness(options.stickySessionId);
-			}
-			if (process != nullptr) {
-				if (process->canBeRoutedTo()) {
-					return RouteResult(process);
-				} else {
-					return RouteResult(NULL, false);
-				}
+			process = findProcessWithLowestBusyness(disablingProcesses);
+			if (process && process->canBeRoutedTo()) {
+				return RouteResult(process);
 			} else {
 				return RouteResult(NULL, true);
 			}
-		}
-	} else {
-		if (OXT_LIKELY(useNewRouting())) {
-			process = findBestProcess(disablingProcesses);
-		} else {
-			process = findProcessWithLowestBusyness(disablingProcesses);
-		}
-		if (process != nullptr) {
-			assert(process->canBeRoutedTo());
-			return RouteResult(process);
-		} else {
-			return RouteResult(NULL, true);
 		}
 	}
 }


### PR DESCRIPTION
The assert at https://github.com/phusion/passenger/blob/1bf36f17820d3b7f46019bc488283e42b224fe8b/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp#L74 was triggered by the process selected by the old routing algo. Since that process is not routable, it does not uphold the invariant documented here: https://github.com/phusion/passenger/blob/1bf36f17820d3b7f46019bc488283e42b224fe8b/src/agent/Core/ApplicationPool/Group/SessionManagement.cpp#L54-L55 so we need to return NULL if the process is not routable, or change the assert & invariant.

 I'm trying the NULL approach first.