### PR TITLE
Fix for rackup v1.0.1 support

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/rack_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/rack_handler.rb
@@ -41,7 +41,7 @@ require 'rbconfig'
 require 'rackup' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
 
 # Rackup was removed in Rack 3, it is now a separate gem
-if Object.const_defined? :Rackup
+if Object.const_defined?(:Rackup) && ::Rackup.const_defined?(:Handler)
   module Rackup
     module Handler
       module PhusionPassenger
@@ -57,7 +57,7 @@ if Object.const_defined? :Rackup
       register :passenger, PhusionPassenger
     end
   end
-elsif Object.const_defined?(:Rack) && Rack.release < '3'
+elsif Object.const_defined?(:Rack) && ::Rack.release < '3'
   module Rack
     module Handler
       module PhusionPassenger


### PR DESCRIPTION
### Summary
This is a fix for the rackup v1.0.1 support that was re-introduced in https://github.com/phusion/passenger/commit/f0c3c829b35beba5d199fec5a635602fab5a3fad (much appreciated, thank you!). As it currently stands, I believe passenger cannot be run with rackup 1.0.1 (to keeping using rack 2) because it's incompatible with the changes made to support rackup v2.1+ in https://github.com/phusion/passenger/commit/9f11e3dcbcbc338364c3dd1e7d984ac322a5f4ea.

Resolves #2602.

### Testing

_Before, passenger 6.0.27_

![Screenshot 2025-04-02 at 4 41 11 PM](https://github.com/user-attachments/assets/d60a2f60-7b4b-4397-bad6-49ae94070d96)

_After, this branch_

![Screenshot 2025-04-02 at 4 42 13 PM](https://github.com/user-attachments/assets/1dde7afa-529d-4595-a9a7-69b932cbc121)