### PR TITLE
Refactor: simplify non-blocking socket connect code

### DIFF
--- a/doc/CxxTestingGuide.md
+++ b/doc/CxxTestingGuide.md
@@ -18,7 +18,7 @@ using namespace Passenger;
 namespace tut {
     // Each test suite has a corresponding context struct, created and
     // deleted for every test case. You can put test case-local state here.
-    struct SomethingTest final: public TestBase {
+    struct SomethingTest: public TestBase {
         Something something;
     };
 

--- a/doc/CxxTestingGuide.md
+++ b/doc/CxxTestingGuide.md
@@ -18,7 +18,7 @@ using namespace Passenger;
 namespace tut {
     // Each test suite has a corresponding context struct, created and
     // deleted for every test case. You can put test case-local state here.
-    struct SomethingTest: public TestBase {
+    struct SomethingTest final: public TestBase {
         Something something;
     };
 

--- a/src/agent/Core/ApplicationPool/Socket.h
+++ b/src/agent/Core/ApplicationPool/Socket.h
@@ -89,10 +89,10 @@ private:
 	Connection connect() const {
 		Connection connection;
 		P_TRACE(3, "Connecting to " << address);
-		NConnect_State state(address, __FILE__, __LINE__);
-		connection.ready = state.connectToServer();
+		auto result = createNonBlockingSocketConnection(address, __FILE__, __LINE__);
+		connection.ready = result.second;
 		connection.fail = true;
-		connection.fd = state.getFd().detach();
+		connection.fd = result.first;
 		connection.wantKeepAlive = false;
 		P_LOG_FILE_DESCRIPTOR_PURPOSE(connection.fd, "App " << pid << " connection");
 		return connection;

--- a/src/agent/Core/ApplicationPool/TestSession.h
+++ b/src/agent/Core/ApplicationPool/TestSession.h
@@ -207,10 +207,9 @@ public:
 								__FILE__, __LINE__);
 
 		// Create client socket (non-blocking)
-		NUnix_State clientState;
-		setupNonBlockingUnixSocket(clientState, socketPath, __FILE__, __LINE__);
-		bool immediatelyConnected = connectToUnixServer(clientState);
-		connection.first = std::move(clientState.fd);
+		auto nbcResult = createNonBlockingUnixSocketConnection( socketPath, __FILE__, __LINE__);
+		bool immediatelyConnected = nbcResult.second;
+		connection.first = FileDescriptor(nbcResult.first, nullptr, 0);
 
 		// Accept connection (blocking)
 		FileDescriptor serverSideFd(oxt::syscalls::accept(serverFd, NULL, NULL),

--- a/src/cxx_supportlib/IOTools/IOUtils.cpp
+++ b/src/cxx_supportlib/IOTools/IOUtils.cpp
@@ -479,180 +479,129 @@ connectToTcpServer(const StaticString &hostname, unsigned int port,
 
 /****** Socket connection establishment (non-blocking) ******/
 
-void
-setupNonBlockingUnixSocket(NUnix_State &state, const StaticString &filename,
-	const char *file, unsigned int line)
-{
-	state.fd.assign(syscalls::socket(PF_UNIX, SOCK_STREAM, 0), file, line);
-	if (state.fd == -1) {
-		int e = errno;
-		throw SystemException("Cannot create a Unix socket file descriptor", e);
-	}
-
-	state.filename = filename;
-	setNonBlocking(state.fd);
-}
-
-bool
-connectToUnixServer(NUnix_State &state) {
-	struct sockaddr_un addr;
-	int ret;
-
-	if (state.filename.size() > sizeof(addr.sun_path) - 1) {
-		string message = "Cannot connect to Unix socket '";
-		message.append(state.filename.data(), state.filename.size());
-		message.append("': filename is too long.");
-		throw RuntimeException(message);
-	}
-
-	addr.sun_family = AF_UNIX;
-	memcpy(addr.sun_path, state.filename.data(), state.filename.size());
-	addr.sun_path[state.filename.size()] = '\0';
-
-	ret = syscalls::connect(state.fd, (const sockaddr *) &addr, sizeof(addr));
-	if (ret == -1) {
-		if (errno == EINPROGRESS || errno == EWOULDBLOCK) {
-			return false;
-		} else if (errno == EISCONN) {
-			return true;
-		} else {
-			int e = errno;
-			string message = "Cannot connect to Unix socket '";
-			message.append(state.filename.data(), state.filename.size());
-			message.append("'");
-			throw SystemException(message, e);
-		}
-	} else {
-		return true;
-	}
-}
-
-void
-setupNonBlockingTcpSocket(NTCP_State &state, const StaticString &hostname, int port,
-	const char *file, unsigned int line)
-{
-	int ret;
-
-	memset(&state.hints, 0, sizeof(state.hints));
-	state.hints.ai_family   = PF_UNSPEC;
-	state.hints.ai_socktype = SOCK_STREAM;
-	ret = getaddrinfo(hostname.toString().c_str(), toString(port).c_str(),
-		&state.hints, &state.res);
-	if (ret != 0) {
-		string message = "Cannot resolve IP address '";
-		message.append(hostname.data(), hostname.size());
-		message.append(":");
-		message.append(toString(port));
-		message.append("': ");
-		message.append(gai_strerror(ret));
-		throw IOException(message);
-	}
-
-	state.fd.assign(syscalls::socket(PF_INET, SOCK_STREAM, 0), file, line);
-	if (state.fd == -1) {
-		int e = errno;
-		throw SystemException("Cannot create a TCP socket file descriptor", e);
-	}
-
-	state.hostname = hostname;
-	state.port = port;
-	setNonBlocking(state.fd);
-}
-
-bool
-connectToTcpServer(NTCP_State &state) {
-	int ret;
-
-	ret = syscalls::connect(state.fd, state.res->ai_addr, state.res->ai_addrlen);
-	if (ret == -1) {
-		if (errno == EINPROGRESS || errno == EWOULDBLOCK) {
-			return false;
-		} else if (errno == EISCONN) {
-			freeaddrinfo(state.res);
-			state.res = NULL;
-			return true;
-		} else {
-			int e = errno;
-			string message = "Cannot connect to TCP socket '";
-			message.append(state.hostname);
-			message.append(":");
-			message.append(toString(state.port));
-			message.append("'");
-			throw SystemException(message, e);
-		}
-	} else {
-		freeaddrinfo(state.res);
-		state.res = NULL;
-		return true;
-	}
-}
-
-NConnect_State::NConnect_State(const StaticString &address, const char *file, unsigned int line)
-{
+std::pair<int, bool>
+createNonBlockingSocketConnection(const StaticString &address, const char *file, unsigned int line) {
 	TRACE_POINT();
-	type = getSocketAddressType(address);
-	switch (type) {
+	switch (getSocketAddressType(address)) {
 	case SAT_UNIX:
-		setupNonBlockingUnixSocket(s_unix, parseUnixSocketAddress(address),
-			file, line);
-		break;
+		return createNonBlockingUnixSocketConnection(parseUnixSocketAddress(address), file, line);
 	case SAT_TCP: {
 		string host;
 		unsigned short port;
 
 		parseTcpSocketAddress(address, host, port);
-		setupNonBlockingTcpSocket(s_tcp, host, port, file, line);
-		break;
+		return createNonBlockingTcpSocketConnection(host, port, file, line);
 	}
 	default:
 		throw ArgumentException(string("Unknown address type for '") + address + "'");
 	}
 }
 
-bool
-NConnect_State::connectToServer() {
-	switch (type) {
-	case SAT_UNIX:
-		return connectToUnixServer(s_unix);
-	case SAT_TCP:
-		return connectToTcpServer(s_tcp);
-	default:
-		throw RuntimeException("Unknown address type");
+std::pair<int, bool>
+createNonBlockingUnixSocketConnection(const StaticString &filename, const char *file, unsigned int line) {
+	struct sockaddr_un addr;
+
+	if (filename.size() > sizeof(addr.sun_path) - 1) {
+		string message = "Cannot connect to Unix socket '";
+		message.append(filename.data(), filename.size());
+		message.append("': filename is too long.");
+		throw ArgumentException(message);
+	}
+
+
+	int fd = syscalls::socket(PF_UNIX, SOCK_STREAM, 0);
+	if (fd == -1) {
+		int e = errno;
+		throw SystemException("Cannot create a Unix socket file descriptor", e);
+	}
+
+	int ret;
+	FdGuard guard(fd, nullptr, 0, true);
+	P_LOG_FILE_DESCRIPTOR_OPEN4(fd, file, line, "NonBlockingUnixSocketConnection");
+	setNonBlocking(fd);
+
+	addr.sun_family = AF_UNIX;
+	memcpy(addr.sun_path, filename.data(), filename.size());
+	addr.sun_path[filename.size()] = '\0';
+
+	ret = syscalls::connect(fd, (const sockaddr *) &addr, sizeof(addr));
+	if (ret == -1) {
+		if (errno == EINPROGRESS || errno == EWOULDBLOCK) {
+			guard.clear();
+			return std::make_pair(fd, false);
+		} else if (errno == EISCONN) {
+			guard.clear();
+			return std::make_pair(fd, true);
+		} else {
+			int e = errno;
+			string message = "Cannot connect to Unix socket '";
+			message.append(filename.data(), filename.size());
+			message.append("'");
+			throw SystemException(message, e);
+		}
+	} else {
+		guard.clear();
+		return std::make_pair(fd, true);
 	}
 }
 
-FileDescriptor &
-NConnect_State::getFd() {
-	switch (type) {
-	case SAT_UNIX:
-		return s_unix.fd;
-	case SAT_TCP:
-		return s_tcp.fd;
-	default:
-		throw RuntimeException("Unknown address type");
+std::pair<int, bool>
+createNonBlockingTcpSocketConnection(const StaticString &hostname, unsigned int port, const char *file, unsigned int line) {
+	const string hostnameCopy = string(hostname.data(), hostname.size());
+	const string portString = toString(port);
+	struct addrinfo hints, *res;
+	int ret;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family   = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	ret = getaddrinfo(hostnameCopy.c_str(), portString.c_str(),
+		&hints, &res);
+	if (ret != 0) {
+		string message = "Cannot resolve IP address '";
+		message.append(hostname.data(), hostname.size());
+		message.append(":");
+		message.append(portString);
+		message.append("': ");
+		message.append(gai_strerror(ret));
+		throw IOException(message);
 	}
-}
 
-NUnix_State &
-NConnect_State::asNUnix_State() {
-	// When we're ready for C++14:
-	// if (type == SAT_UNIX) {
-	// 	return *reinterpret_cast<NUnix_State *>(storage);
-	// } else {
-	// 	P_BUG("Address type is not TCP");
-	// }
-	return s_unix;
-}
 
-NTCP_State &
-NConnect_State::asNTCP_State() {
-	// When we're ready for C++14:
-	// if (type == SAT_TCP) {
-	// 	return *reinterpret_cast<NTCP_State *>(storage);
-	// } else {
-	// 	P_BUG("Address type is not TCP");
-	// }
-	return s_tcp;
+	int fd = syscalls::socket(PF_INET, SOCK_STREAM, 0);
+	if (fd == -1) {
+		int e = errno;
+		throw SystemException("Cannot create a TCP socket file descriptor", e);
+	}
+
+	FdGuard guard(fd, nullptr, 0, true);
+	P_LOG_FILE_DESCRIPTOR_OPEN4(fd, file, line, "NonBlockingTcpSocketConnection");
+	setNonBlocking(fd);
+
+
+	ret = syscalls::connect(fd, res->ai_addr, res->ai_addrlen);
+	if (ret == -1) {
+		if (errno == EINPROGRESS || errno == EWOULDBLOCK) {
+			guard.clear();
+			return make_pair(fd, false);
+		} else if (errno == EISCONN) {
+			freeaddrinfo(res);
+			guard.clear();
+			return make_pair(fd, true);
+		} else {
+			int e = errno;
+			string message = "Cannot connect to TCP socket '";
+			message.append(hostname);
+			message.append(":");
+			message.append(portString);
+			message.append("'");
+			throw SystemException(message, e);
+		}
+	} else {
+		freeaddrinfo(res);
+		guard.clear();
+		return make_pair(fd, true);
+	}
 }
 
 
@@ -736,14 +685,10 @@ callAccept4(int sock, struct sockaddr *addr, socklen_t *addr_len, int options) {
 bool
 pingTcpServer(const StaticString &host, unsigned int port, unsigned long long *timeout) {
 	TRACE_POINT();
-	NTCP_State state;
-
-	setupNonBlockingTcpSocket(state, host, port, __FILE__, __LINE__);
+	std::pair<int, bool> nbcResult;
 
 	try {
-		if (connectToTcpServer(state)) {
-			return true;
-		}
+		nbcResult = createNonBlockingTcpSocketConnection(host, port, __FILE__, __LINE__);
 	} catch (const SystemException &e) {
 		if (e.code() == ECONNREFUSED) {
 			return false;
@@ -751,13 +696,17 @@ pingTcpServer(const StaticString &host, unsigned int port, unsigned long long *t
 			throw e;
 		}
 	}
+	FdGuard guard(nbcResult.first, nullptr, 0, true);
+	if (nbcResult.second) {
+		return true;
+	}
 
 	// Cannot connect to the port yet, but that may not mean the
 	// port is unavailable. So poll the socket.
 
 	bool connectable;
 	try {
-		connectable = waitUntilWritable(state.fd, timeout);
+		connectable = waitUntilWritable(nbcResult.first, timeout);
 	} catch (const SystemException &e) {
 		throw SystemException("Error polling TCP socket "
 			+ host + ":" + toString(port), e.code());
@@ -767,24 +716,21 @@ pingTcpServer(const StaticString &host, unsigned int port, unsigned long long *t
 		return false;
 	}
 
-	// Try to connect the socket one last time.
+	// Now check the final connection establishment status.
 
-	try {
-		return connectToTcpServer(state);
-	} catch (const SystemException &e) {
-		if (e.code() == ECONNREFUSED) {
-			return false;
-		} else if (e.code() == EISCONN || e.code() == EINVAL) {
-			#ifdef __FreeBSD__
-				// Work around bug in FreeBSD (discovered on
-				// January 20 2013 in daemon_controller)
-				return false;
-			#else
-				throw e;
-			#endif
-		} else {
-			throw e;
-		}
+	int connectError = 0;
+	socklen_t connectErrorLen = sizeof(connectError);
+	if (getsockopt(nbcResult.first, SOL_SOCKET, SO_ERROR, &connectError, &connectErrorLen) == -1) {
+		throw SystemException("Error checking TCP socket " + host + ":" + toString(port)
+			+ " connection establishment status", connectError);
+	}
+	if (connectError == 0) {
+		return true;
+	} else if (connectError == ECONNREFUSED) {
+		return false;
+	} else {
+		throw SystemException("Error connecting to TCP socket " + host + ":"
+			+ toString(port), connectError);
 	}
 }
 

--- a/src/cxx_supportlib/IOTools/IOUtils.h
+++ b/src/cxx_supportlib/IOTools/IOUtils.h
@@ -225,137 +225,55 @@ int connectToTcpServer(const StaticString &hostname, unsigned int port,
 
 /****** Socket connection establishment (non-blocking) ******/
 
-/** State structure for non-blocking connectToUnixServer(). */
-struct NUnix_State {
-	FileDescriptor fd;
-	string filename;
-};
-
-/** State structure for non-blocking connectToTcpServer(). */
-struct NTCP_State {
-	FileDescriptor fd;
-	struct addrinfo hints, *res;
-	string hostname;
-	int port;
-
-	NTCP_State() {
-		memset(&hints, 0, sizeof(hints));
-		res = NULL;
-		port = 0;
-	}
-
-	~NTCP_State() {
-		if (res != NULL) {
-			freeaddrinfo(res);
-		}
-	}
-};
+/**
+ * Establish a socket connection in non-blocking mode.
+ *
+ * @param address An address as accepted by getSocketAddressType().
+ * @param file The name of the source file that called this function,
+ *             for file descriptor logging purposes.
+ * @param line The line in the source file that called this function.
+ * @return The file descriptor of the connected client socket, plus whether
+ *   it was immediately connected (true) or pending (false). If pending,
+ *   the caller should poll() on the socket until it's writable.
+ * @throws ArgumentException Something went wrong.
+ * @throws IOException Something went wrong.
+ * @throws SystemException Something went wrong.
+ * @throws boost::thread_interrupted A system call has been interrupted.
+ */
+std::pair<int, bool> createNonBlockingSocketConnection(const StaticString &address, const char *file, unsigned int line);
 
 /**
- * Setup a Unix domain socket for non-blocking connecting. When done,
- * the file descriptor can be accessed through <tt>state.fd</tt>.
+ * Establish a Unix domain socket connection in non-blocking mode.
  *
- * @param state A state structure.
  * @param filename The filename of the socket to connect to.
  * @param file The name of the source file that called this function,
  *             for file descriptor logging purposes.
  * @param line The line in the source file that called this function.
- * @throws SystemException Something went wrong.
- * @throws boost::thread_interrupted A system call has been interrupted.
- * @ingroup Support
- */
-void setupNonBlockingUnixSocket(NUnix_State & restrict_ref state,
-	const StaticString & restrict_ref filename, const char *file,
-	unsigned int line);
-
-/**
- * Connect a Unix domain socket in non-blocking mode.
- *
- * @param state A state structure.
- * @return True if the socket was successfully connected, false if the socket isn't
- *         ready yet, in which case the caller should select() on the socket until it's writable.
- * @throws RuntimeException Something went wrong.
+ * @return The file descriptor of the connected client socket, plus whether
+ *   it was immediately connected (true) or pending (false). If pending,
+ *   the caller should poll() on the socket until it's writable.
+ * @throws ArgumentException Something went wrong.
  * @throws SystemException Something went wrong while connecting to the Unix server.
  * @throws boost::thread_interrupted A system call has been interrupted.
- * @ingroup Support
  */
-bool connectToUnixServer(NUnix_State &state);
+std::pair<int, bool> createNonBlockingUnixSocketConnection(const StaticString &filename, const char *file, unsigned int line);
 
 /**
- * Setup a TCP socket for non-blocking connecting. When done,
- * the file descriptor can be accessed through <tt>state.fd</tt>.
+ * Establish a TCP socket connection in non-blocking mode.
  *
- * @param state A state structure.
  * @param hostname The host name of the TCP server.
  * @param port The port number of the TCP server.
  * @param file The name of the source file that called this function,
  *             for file descriptor logging purposes.
  * @param line The line in the source file that called this function.
+ * @return The file descriptor of the connected client socket, plus whether
+ *   it was immediately connected (true) or pending (false). If pending,
+ *   the caller should poll() on the socket until it's writable.
  * @throws IOException Something went wrong.
  * @throws SystemException Something went wrong.
  * @throws boost::thread_interrupted A system call has been interrupted.
- * @ingroup Support
  */
-void setupNonBlockingTcpSocket(NTCP_State & restrict_ref state,
-	const StaticString & restrict_ref hostname,
-	int port, const char *file, unsigned int line);
-
-/**
- * Connect a TCP socket in non-blocking mode.
- *
- * @param state A state structure.
- * @return True if the socket was successfully connected, false if the socket isn't
- *         ready yet, in which case the caller should select() on the socket until it's writable.
- * @throws SystemException Something went wrong while connecting to the server.
- * @throws boost::thread_interrupted A system call has been interrupted.
- * @ingroup Support
- */
-bool connectToTcpServer(NTCP_State &state);
-
-struct NConnect_State {
-private:
-	NUnix_State s_unix;
-	NTCP_State s_tcp;
-
-public:
-	ServerAddressType type;
-
-	/**
-	 * Setup a socket for non-blocking connecting to the given address.
-	 *
-	 * @param address An address as accepted by getSocketAddressType().
-	 * @param file The name of the source file that called this function,
-	 *             for file descriptor logging purposes.
-	 * @param line The line in the source file that called this function.
-	 * @throws ArgumentException Unknown address type.
-	 * @throws RuntimeException Something went wrong.
-	 * @throws SystemException Something went wrong.
-	 * @throws IOException Something went wrong.
-	 * @throws boost::thread_interrupted A system call has been interrupted.
-	 */
-	NConnect_State(const StaticString & restrict_ref address, const char *file, unsigned int line);
-
-	NUnix_State &asNUnix_State();
-	NTCP_State &asNTCP_State();
-
-	/**
-	 * Connect a socket in non-blocking mode.
-	 *
-	 * @return True if the socket was successfully connected, false if the socket isn't
-	 *         ready yet, in which case the caller should select() on the socket until it's writable.
-	 * @throws RuntimeException Something went wrong.
-	 * @throws SystemException Something went wrong.
-	 * @throws boost::thread_interrupted A system call has been interrupted.
-	 */
-	bool connectToServer();
-
-	/**
-	 * Gets the connection file descriptor.
-	 *
-	 * @pre \c connectToServer() was called
-	 */
-	FileDescriptor &getFd();
-};
+std::pair<int, bool> createNonBlockingTcpSocketConnection(const StaticString &hostname, unsigned int port, const char *file, unsigned int line);
 
 
 /****** Other ******/
@@ -396,6 +314,7 @@ int callAccept4(int sock,
  * deducted from the `*timeout` value. A timeout of 100000 microseconds is
  * recommended for most use cases.
  *
+ * @throws ArgumentException Something went wrong.
  * @throws IOException Something went wrong.
  * @throws SystemException Something went wrong.
  * @throws boost::thread_interrupted A system call has been interrupted.

--- a/test/cxx/Core/SpawningKit/HandshakePerformTest.cpp
+++ b/test/cxx/Core/SpawningKit/HandshakePerformTest.cpp
@@ -12,7 +12,7 @@ using namespace Passenger;
 using namespace Passenger::SpawningKit;
 
 namespace tut {
-	struct Core_SpawningKit_HandshakePerformTest: public TestBase {
+	struct Core_SpawningKit_HandshakePerformTest final: public TestBase {
 		WrapperRegistry::Registry wrapperRegistry;
 		SpawningKit::Context::Schema schema;
 		SpawningKit::Context context;
@@ -105,19 +105,19 @@ namespace tut {
 		}
 	};
 
-	struct FreePortDebugSupport: public HandshakePerform::DebugSupport {
+	struct FreePortDebugSupport final: public HandshakePerform::DebugSupport {
 		Core_SpawningKit_HandshakePerformTest *test;
 		HandshakeSession *session;
 		AtomicInt expectedStartPort;
 
-		virtual void beginWaitUntilSpawningFinished() {
+		virtual void beginWaitUntilSpawningFinished() override {
 			expectedStartPort = session->expectedStartPort;
 			test->counter++;
 		}
 	};
 
-	struct CrashingDebugSupport: public HandshakePerform::DebugSupport {
-		virtual void beginWaitUntilSpawningFinished() {
+	struct CrashingDebugSupport final: public HandshakePerform::DebugSupport {
+		virtual void beginWaitUntilSpawningFinished() override {
 			throw RuntimeException("oh no!");
 		}
 	};

--- a/test/cxx/Core/SpawningKit/HandshakePerformTest.cpp
+++ b/test/cxx/Core/SpawningKit/HandshakePerformTest.cpp
@@ -12,7 +12,7 @@ using namespace Passenger;
 using namespace Passenger::SpawningKit;
 
 namespace tut {
-	struct Core_SpawningKit_HandshakePerformTest final: public TestBase {
+	struct Core_SpawningKit_HandshakePerformTest: public TestBase {
 		WrapperRegistry::Registry wrapperRegistry;
 		SpawningKit::Context::Schema schema;
 		SpawningKit::Context context;


### PR DESCRIPTION
Get rid of NXXX_State. The old structure split up socket fd creation and connection establishment mainly because pingTcpSocket() needed to connect twice on the same fd. However, I discovered pingTcpSocket() was just doing things wrong: instead of connecting on the same fd again after having polled for writability, we're supposed to use getsockopt(SO_ERROR) to check whether the connection establishment was successful. By doing so, the NXXX_State structure is no longer necessary, so we now put non-blocking socket connection establishment code in single, simple functions.

Introduces:
- createNonBlockingSocketConnection()
- createNonBlockingUnixSocketConnection()
- createNonBlockingTcpSocketConnection()