### PR TITLE
Move FdGuard to IOUtils and improve it

### DIFF
--- a/src/agent/Core/ApplicationPool/Implementation.cpp
+++ b/src/agent/Core/ApplicationPool/Implementation.cpp
@@ -193,7 +193,7 @@ void processAndLogNewSpawnException(SpawningKit::SpawnException &e, const Option
 				getSystemTempDir());
 			fd = mkstemp(filename);
 		#endif
-		FdGuard guard(fd, NULL, 0, true);
+		FdGuard guard(fd, nullptr, 0);
 		if (fd == -1) {
 			int e = errno;
 			throw SystemException("Cannot generate a temporary filename",

--- a/src/agent/Core/CoreMain.cpp
+++ b/src/agent/Core/CoreMain.cpp
@@ -88,6 +88,7 @@
 #include <Utils.h>
 #include <Utils/Timer.h>
 #include <IOTools/MessageIO.h>
+#include <IOTools/IOUtils.h>
 #include <Core/OptionParser.h>
 #include <Core/Controller.h>
 #include <Core/ApiServer.h>

--- a/src/agent/Core/SpawningKit/Handshake/Perform.h
+++ b/src/agent/Core/SpawningKit/Handshake/Perform.h
@@ -50,6 +50,7 @@
 #include <FileDescriptor.h>
 #include <FileTools/FileManip.h>
 #include <FileTools/PathManip.h>
+#include <IOTools/IOUtils.h>
 #include <Utils.h>
 #include <Utils/ScopeGuard.h>
 #include <SystemTools/SystemTime.h>

--- a/src/cxx_supportlib/IOTools/IOUtils.cpp
+++ b/src/cxx_supportlib/IOTools/IOUtils.cpp
@@ -29,6 +29,7 @@
 	// https://bugzilla.redhat.com/show_bug.cgi?id=165427
 	// Also needed for SO_PEERCRED.
 	#define _GNU_SOURCE
+#include <exception>
 #endif
 
 #include <oxt/system_calls.hpp>
@@ -672,13 +673,23 @@ FdGuard::FdGuard(int fd, const char *sourceFile, unsigned int sourceLine)
 	}
 }
 
-FdGuard::~FdGuard() {
+FdGuard::~FdGuard() noexcept(false) {
 	if (mFd != -1) {
 		try {
 			safelyClose(mFd);
 		} catch (const std::exception &e) {
-			P_WARN("Error closing file descriptor " << mFd << ": " << e.what());
-			return;
+			bool uncaughtException =
+				#if __cplusplus >= 201703L
+					std::uncaught_exceptions() > 0;
+				#else
+					std::uncaught_exception();
+				#endif
+			if (uncaughtException) {
+				P_WARN("Error closing file descriptor " << mFd << ": " << e.what());
+				return;
+			} else {
+				throw e;
+			}
 		}
 		P_LOG_FILE_DESCRIPTOR_CLOSE(mFd);
 	}
@@ -698,12 +709,12 @@ FdGuard::operator=(FdGuard &&other) {
 }
 
 void
-FdGuard::clear() {
+FdGuard::clear() noexcept {
 	mFd = -1;
 }
 
 void
-FdGuard::runNow() {
+FdGuard::runNow() noexcept(false) {
 	if (mFd != -1) {
 		safelyClose(mFd);
 		P_LOG_FILE_DESCRIPTOR_CLOSE(mFd);

--- a/src/cxx_supportlib/IOTools/IOUtils.cpp
+++ b/src/cxx_supportlib/IOTools/IOUtils.cpp
@@ -215,7 +215,7 @@ createUnixServer(const StaticString &filename, unsigned int backlogSize, bool au
 		throw SystemException("Cannot create a Unix socket file descriptor", e);
 	}
 
-	FdGuard guard(fd, file, line, true);
+	FdGuard guard(fd, file, line);
 	addr.sun_family = AF_LOCAL;
 	strncpy(addr.sun_path, filename.c_str(), filename.size());
 	addr.sun_path[filename.size()] = '\0';
@@ -306,7 +306,7 @@ createTcpServer(const char *address, unsigned short port, unsigned int backlogSi
 	}
 	// Ignore SO_REUSEADDR error, it's not fatal.
 
-	FdGuard guard(fd, file, line, true);
+	FdGuard guard(fd, file, line);
 	if (family == AF_INET) {
 		ret = syscalls::bind(fd, (const struct sockaddr *) &addr.v4, sizeof(struct sockaddr_in));
 	} else {
@@ -369,7 +369,7 @@ connectToUnixServer(const StaticString &filename, const char *file,
 		throw SystemException("Cannot create a Unix socket file descriptor", e);
 	}
 
-	FdGuard guard(fd, file, line, true);
+	FdGuard guard(fd, file, line);
 	int ret;
 	struct sockaddr_un addr;
 
@@ -653,6 +653,62 @@ NConnect_State::asNTCP_State() {
 	// 	P_BUG("Address type is not TCP");
 	// }
 	return s_tcp;
+}
+
+
+/****** Scope guards ******/
+
+FdGuard::FdGuard(FdGuard &&other)
+	: mFd(other.mFd)
+{
+	other.mFd = -1;
+}
+
+FdGuard::FdGuard(int fd, const char *sourceFile, unsigned int sourceLine)
+	: mFd(fd)
+{
+	if (mFd != -1 && sourceFile != nullptr) {
+		P_LOG_FILE_DESCRIPTOR_OPEN3(fd, sourceFile, sourceLine);
+	}
+}
+
+FdGuard::~FdGuard() {
+	if (mFd != -1) {
+		try {
+			safelyClose(mFd);
+		} catch (const std::exception &e) {
+			P_WARN("Error closing file descriptor " << mFd << ": " << e.what());
+			return;
+		}
+		P_LOG_FILE_DESCRIPTOR_CLOSE(mFd);
+	}
+}
+
+FdGuard &
+FdGuard::operator=(FdGuard &&other) {
+	if (this != &other) {
+		if (mFd != -1) {
+			safelyClose(mFd);
+			P_LOG_FILE_DESCRIPTOR_CLOSE(mFd);
+		}
+		mFd = other.mFd;
+		other.mFd = -1;
+	}
+	return *this;
+}
+
+void
+FdGuard::clear() {
+	mFd = -1;
+}
+
+void
+FdGuard::runNow() {
+	if (mFd != -1) {
+		safelyClose(mFd);
+		P_LOG_FILE_DESCRIPTOR_CLOSE(mFd);
+		mFd = -1;
+	}
 }
 
 

--- a/src/cxx_supportlib/IOTools/IOUtils.h
+++ b/src/cxx_supportlib/IOTools/IOUtils.h
@@ -370,16 +370,21 @@ public:
 	FdGuard(const FdGuard &other) = delete;
 	FdGuard(FdGuard &&other);
 	FdGuard(int fd, const char *sourceFile, unsigned int sourceLine);
-	~FdGuard();
+	/** @throws SystemException File descriptor close error. If exception is already being thrown, then only warns. */
+	~FdGuard() noexcept(false);
 
 	FdGuard &operator=(const FdGuard &other) = delete;
 	FdGuard &operator=(FdGuard &&other);
 
 	/** Don't close file descriptor at object destruction. */
-	void clear();
+	void clear() noexcept;
 
-	/** Close file descriptor now. Idempotent. */
-	void runNow();
+	/**
+	 * Close file descriptor now. Idempotent.
+	 *
+	 * @throws SystemException
+	 */
+	void runNow() noexcept(false);
 };
 
 

--- a/src/cxx_supportlib/IOTools/IOUtils.h
+++ b/src/cxx_supportlib/IOTools/IOUtils.h
@@ -358,6 +358,31 @@ public:
 };
 
 
+/****** Scope guards ******/
+
+/** RAII construct for ensuring that a file descriptor gets closed at scope exit. */
+class FdGuard {
+private:
+	int mFd = -1;
+
+public:
+	FdGuard() { }
+	FdGuard(const FdGuard &other) = delete;
+	FdGuard(FdGuard &&other);
+	FdGuard(int fd, const char *sourceFile, unsigned int sourceLine);
+	~FdGuard();
+
+	FdGuard &operator=(const FdGuard &other) = delete;
+	FdGuard &operator=(FdGuard &&other);
+
+	/** Don't close file descriptor at object destruction. */
+	void clear();
+
+	/** Close file descriptor now. Idempotent. */
+	void runNow();
+};
+
+
 /****** Other ******/
 
 typedef ssize_t (*WritevFunction)(int fildes, const struct iovec *iov, int iovcnt);

--- a/src/cxx_supportlib/Utils/ScopeGuard.h
+++ b/src/cxx_supportlib/Utils/ScopeGuard.h
@@ -117,38 +117,6 @@ public:
 	}
 };
 
-class FdGuard: public noncopyable {
-private:
-	int fd;
-	bool ignoreErrors;
-
-public:
-	FdGuard(int _fd, const char *file, unsigned int line, bool _ignoreErrors = false)
-		: fd(_fd),
-		  ignoreErrors(_ignoreErrors)
-	{
-		if (_fd != -1 && file != NULL) {
-			P_LOG_FILE_DESCRIPTOR_OPEN3(_fd, file, line);
-		}
-	}
-
-	~FdGuard() {
-		runNow();
-	}
-
-	void clear() {
-		fd = -1;
-	}
-
-	void runNow() {
-		if (fd != -1) {
-			safelyClose(fd, ignoreErrors);
-			P_LOG_FILE_DESCRIPTOR_CLOSE(fd);
-			fd = -1;
-		}
-	}
-};
-
 
 } // namespace Passenger
 


### PR DESCRIPTION
Improvements:
- Make it moveable.
- Make it unabuseable: don't throwing exceptions in destructor if exception is already being thrown (= undefined behavior). Just warn.

Partially addresses #2596.