### PR TITLE
Activate mobile viewport for "queue full" message

### DIFF
--- a/src/agent/Core/Controller/CheckoutSession.cpp
+++ b/src/agent/Core/Controller/CheckoutSession.cpp
@@ -353,9 +353,13 @@ Controller::writeRequestQueueFullExceptionErrorResponse(Client *client, Request 
 		" due to: " << e->what());
 
 	endRequestWithSimpleResponse(&client, &req,
+		"<html><head>"
+		"<meta name='viewport' content='width=device-width, initial-scale=1'>"
+		"</head><body>"
 		"<h2>This website is under heavy load (queue full)</h2>"
 		"<p>We're sorry, too many people are accessing this website at the same "
-		"time. We're working on this problem. Please try again later.</p>",
+		"time. We're working on this problem. Please try again later.</p>"
+		"</body></html>",
 		requestQueueOverflowStatusCode);
 }
 


### PR DESCRIPTION
Right now the "queue full" message is an invalid HTML page. This renders fine, but at least on mobile this is far from optimal because the text is rendered very small.

Thats why I added a minimal HTML skeleton and adjusted the  viewport to have a (still not beauty) but better readable message.

ref https://github.com/openstreetmap/openstreetmap-website/issues/6563