### PR TITLE
Remove the pre-fork GC.start

### DIFF
--- a/src/ruby_supportlib/phusion_passenger/preloader_shared_helpers.rb
+++ b/src/ruby_supportlib/phusion_passenger/preloader_shared_helpers.rb
@@ -101,9 +101,6 @@ module PhusionPassenger
       LoaderSharedHelpers.record_journey_step_begin('PRELOADER_FORK_SUBPROCESS',
         'STEP_IN_PROGRESS', work_dir)
 
-      # Improve copy-on-write friendliness.
-      GC.start
-
       begin
         pid = fork
       rescue SystemCallError => e


### PR DESCRIPTION
This doesn't actually help CoW friendliness, you'd need to run it 3 times for all objects to be promoted to the old generation.

But more importantly, you only want to do this before the very first fork, for any subsequent forks, it's best not to trigger GC.

Also `GC.start` can be quite taxing on large monolith, easily over 1s, which makes respawning dead workers slower and burn CPU for little to no gains.

In addition, modern Ruby versions have `Process.warmup` which does the same and more, but faster.

So ideally it would be preferable to expose a hook and let users decide what they want to do here.