### PR TITLE
Prefer String#b over `force_encoding` and avoid mutating strings

### DIFF
--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -603,12 +603,7 @@ private
     # We do this instead of using #file, for Ruby 1.8.5 support.
     digest = Digest::SHA256.new
     File.open(path, "rb") do |f|
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-        buf = String.new(encoding: Encoding::BINARY)
-      else
-        buf = ""
-        buf.force_encoding('binary') if buf.respond_to?(:force_encoding)
-      end
+      buf = ''.b
       while !f.eof?
         f.read(1024 * 16, buf)
         digest.update(buf)

--- a/dev/ruby_server.rb
+++ b/dev/ruby_server.rb
@@ -135,12 +135,7 @@ private
   def handle_next_client(forward_connection)
     client = @server.accept
     begin
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-        buffer = String.new(encoding: Encoding::BINARY)
-      else
-        buffer = ""
-        buffer.force_encoding('binary') if buffer.respond_to?(:force_encoding)
-      end
+      buffer = "".b
       while true
         begin
           read_header(client, buffer)

--- a/src/ruby_supportlib/phusion_passenger/admin_tools/memory_stats.rb
+++ b/src/ruby_supportlib/phusion_passenger/admin_tools/memory_stats.rb
@@ -251,7 +251,7 @@ module PhusionPassenger
           ps_output = `#{ps} -w -o pid,ppid,nlwp,vsz,rss,%cpu,command`
           threads_known = true
         end
-        list = force_binary(ps_output).split("\n")
+        list = ps_output.b.split("\n")
         list.shift
         list.each do |line|
           line.gsub!(/^ */, '')
@@ -297,16 +297,6 @@ module PhusionPassenger
         end
       rescue Errno::EACCES, Errno::ENOENT, Errno::ESRCH
         nil
-      end
-
-      if ''.respond_to?(:force_encoding)
-        def force_binary(str)
-          str.force_encoding('binary')
-        end
-      else
-        def force_binary(str)
-          str
-        end
       end
     end
 

--- a/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb
+++ b/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb
@@ -101,12 +101,7 @@ module PhusionPassenger
       def main_loop(finish_callback)
         socket_wrapper = Utils::UnseekableSocket.new
         channel        = MessageChannel.new
-        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-          buffer = String.new(encoding: Encoding::BINARY)
-        else
-          buffer = ""
-          buffer.force_encoding('binary') if buffer.respond_to?(:force_encoding)
-        end
+        buffer         = ''.b
 
         begin
           finish_callback.call

--- a/src/ruby_supportlib/phusion_passenger/standalone/start_command/nginx_engine.rb
+++ b/src/ruby_supportlib/phusion_passenger/standalone/start_command/nginx_engine.rb
@@ -324,13 +324,9 @@ module PhusionPassenger
         end
 
         def serialize_strset(*items)
-          if "".respond_to?(:force_encoding)
-            items = items.map { |x| x.force_encoding('binary') }
-            null  = "\0".force_encoding('binary')
-          else
-            null  = "\0"
-          end
-          [ items.join(null) ].pack('m*').gsub("\n", "").strip
+          items = items.map(&:b)
+          null  = "\0".b
+          return [items.join(null)].pack('m*').gsub("\n", "").strip
         end
 
         #####################

--- a/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
+++ b/src/ruby_supportlib/phusion_passenger/utils/unseekable_socket.rb
@@ -181,9 +181,9 @@ module PhusionPassenger
         if @simulate_eof
           length, buffer = args
           if buffer
-            buffer.replace(binary_string(""))
+            buffer.replace("".b)
           else
-            buffer = binary_string("")
+            buffer = "".b
           end
           if length
             return nil
@@ -292,16 +292,6 @@ module PhusionPassenger
 
       def raise_error_because_activity_disallowed!
         raise IOError, "It is not possible to read or write from the client socket because the current."
-      end
-
-      if ''.respond_to?(:force_encoding)
-        def binary_string(str)
-          ''.force_encoding('binary')
-        end
-      else
-        def binary_string(str)
-          ''
-        end
       end
     end
 

--- a/test/integration_tests/native_packaging_spec.rb
+++ b/test/integration_tests/native_packaging_spec.rb
@@ -136,9 +136,8 @@ end
 describe 'A natively packaged Phusion Passenger' do
   def capture_output(command)
     output = `#{command}`.strip
-    if output.respond_to?(:force_encoding)
-      output.force_encoding('utf-8')
-    end
+    output.force_encoding(Encoding::UTF_8)
+
     if $?.exitstatus == 0
       output
     else

--- a/test/integration_tests/shared/example_webapp_tests.rb
+++ b/test/integration_tests/shared/example_webapp_tests.rb
@@ -64,9 +64,9 @@ RSpec.shared_examples_for 'an example web app' do
         io.read
       end
       response.should ==
-        binary_string("name 1 = Kotonoha\n") <<
-        binary_string("name 2 = Sekai\n") <<
-        binary_string('data = ') << static_file.read
+        "name 1 = Kotonoha\n".b <<
+        "name 2 = Sekai\n".b <<
+        "data = ".b << static_file.read
     ensure
       static_file.close
     end

--- a/test/integration_tests/standalone_tests.rb
+++ b/test/integration_tests/standalone_tests.rb
@@ -32,9 +32,8 @@ describe 'Passenger Standalone' do
 
   def capture_output(command)
     output = `#{command} 2>&1`.strip
-    if output.respond_to?(:force_encoding)
-      output.force_encoding('utf-8')
-    end
+    output.force_encoding(Encoding::UTF_8)
+
     if $?.exitstatus == 0
       output
     else

--- a/test/stub/rack/config.ru
+++ b/test/stub/rack/config.ru
@@ -50,9 +50,9 @@ app = lambda do |env|
     text_response('This is the uncached version of /cached')
   when '/upload_with_params'
     req = Rack::Request.new(env)
-    name1 = binary_string(req.params['name1'])
-    name2 = binary_string(req.params['name2'])
-    file = req.params['data'][:tempfile]
+    name1 = req.params["name1"].b
+    name2 = req.params["name2"].b
+    file = req.params["data"][:tempfile]
     file.binmode
     text_response(
       "name 1 = #{name1}\n" <<

--- a/test/stub/rack/library.rb
+++ b/test/stub/rack/library.rb
@@ -1,16 +1,6 @@
 # encoding: binary
 
 def text_response(body)
-  body = binary_string(body.to_s)
-  [ 200, { 'Content-Type' => 'text/plain', 'Content-Length' => body.size.to_s }, [ body ] ]
-end
-
-if ''.respond_to?(:force_encoding)
-  def binary_string(str)
-    str.force_encoding('binary')
-  end
-else
-  def binary_string(str)
-    str
-  end
+  body = body.to_s.b
+  return [200, { "Content-Type" => "text/plain", "Content-Length" => body.size.to_s }, [body]]
 end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -351,17 +351,6 @@ module TestHelper
       instance
     end
   end
-
-  if ''.respond_to?(:force_encoding)
-    def binary_string(str)
-      str.force_encoding('binary')
-    end
-  else
-    def binary_string(str)
-      str
-    end
-  end
-
 end
 
 File.class_eval do


### PR DESCRIPTION
I started recording deprecation warning in production in the hope to enable Ruby's `--enable-frozen-string-literal`, but ran into two string literal deprecation warnings coming from passenger, one of which is:

```
src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb:90: warning: literal string will be frozen in the future
```

Since passenger requires Ruby 2.5, all these check for `force_encoding` are useless, we can assume the presence of `String#b`.