### PR TITLE
Migrate Vimeo video links to YouTube

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Phusion Passenger is mostly written in C++, but the build system and various sma
 <a name="dev_quickstart"></a>
 ### Developer QuickStart
 
-<a href="https://vimeo.com/phusionnl/review/97427161/15cb4cc59a"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/passenger_developer_quickstart.png"></a>
+<a href="https://youtu.be/CSpk9mfKdbc"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/passenger_developer_quickstart.png"></a>
 
 _Watch the Developer QuickStart screencast_
 
@@ -102,9 +102,9 @@ Phusion Passenger's design and architecture is documented in detail in the [Desi
 <a name="code_walkthrough"></a>
 ### Code Walkthrough
 
-<a href="http://vimeo.com/phusionnl/review/98027409/03ba678684"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/code_walkthrough.png"></a>
+<a href="https://youtu.be/exugD98pqQc"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/code_walkthrough.png"></a>
 
-We have [a video](http://vimeo.com/phusionnl/review/98027409/03ba678684) which walks you through the Phusion Passenger codebase, showing you step-by-step how things fit together. It complements the [Design & Architecture](https://www.phusionpassenger.com/documentation/Design%20and%20Architecture.html) document.
+We have [a video](https://youtu.be/exugD98pqQc) which walks you through the Phusion Passenger codebase, showing you step-by-step how things fit together. It complements the [Design & Architecture](https://www.phusionpassenger.com/documentation/Design%20and%20Architecture.html) document.
 
 <a name="build_system"></a>
 ### Compilation and build system

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Phusion Passenger®](https://www.phusionpassenger.com/) is a web server and application server, designed to be fast, robust and lightweight. It takes a lot of complexity out of deploying web apps, adds powerful enterprise-grade features that are useful in production, and makes administration much easier and less complex. Phusion Passenger supports Ruby, Python, Node.js and Meteor, and is being used by high-profile companies such as **Apple, Pixar, New York Times, AirBnB, Juniper** etc as well as [over 650.000 websites](http://trends.builtwith.com/Web-Server/Phusion-Passenger).
 
-<a href="https://vimeo.com/224923750"><img src="https://github.com/phusion/passenger/blob/stable-5.2/images/justin.png" height="400"></a><br><em>Phusion Passenger - the smart app server</em>
+<a href="https://youtu.be/fFFnKvedU9w"><img src="https://github.com/phusion/passenger/blob/stable-5.2/images/justin.png" height="400"></a><br><em>Phusion Passenger - the smart app server</em>
 
 <p>What makes Passenger so fast and reliable is its <strong>C++</strong> core, its <strong>zero-copy</strong> architecture, its <strong>watchdog</strong> system and its <strong>hybrid</strong> evented, multi-threaded and multi-process design.</p>
 

--- a/doc/DeveloperQuickstart.md
+++ b/doc/DeveloperQuickstart.md
@@ -1,6 +1,6 @@
 # Phusion Passenger Developer QuickStart
 
-<a href="https://vimeo.com/phusionnl/review/97427161/15cb4cc59a"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/passenger_developer_quickstart.png"></a>
+<a href="https://youtu.be/CSpk9mfKdbc"><img src="http://blog.phusion.nl/wp-content/uploads/2014/06/passenger_developer_quickstart.png"></a>
 
 _Watch the Developer QuickStart screencast_
 

--- a/src/README.md
+++ b/src/README.md
@@ -4,4 +4,4 @@ If you aren't familiar with the Passenger codebase then we encourage you to read
 
  * [Contributors Guide](https://github.com/phusion/passenger/blob/master/CONTRIBUTING.md)
  * [Design & Architecture](https://www.phusionpassenger.com/documentation/Design%20and%20Architecture.html)
- * [Code walkthrough](http://vimeo.com/phusionnl/review/98027409/03ba678684)
+ * [Code walkthrough](https://youtu.be/exugD98pqQc)


### PR DESCRIPTION
Phusion's videos have moved from Vimeo to YouTube. This repoints the video links in this repo at the new YouTube URLs.

| Video | Old (Vimeo) | New (YouTube) |
|---|---|---|
| Passenger Commercial | `vimeo.com/224923750` | https://youtu.be/fFFnKvedU9w |
| Developer QuickStart | `vimeo.com/phusionnl/review/97427161/…` | https://youtu.be/CSpk9mfKdbc |
| Code Walkthrough | `vimeo.com/phusionnl/review/98027409/…` | https://youtu.be/exugD98pqQc |

**Files changed:** `README.md`, `CONTRIBUTING.md`, `doc/DeveloperQuickstart.md`, `src/README.md`

All three YouTube videos verified publicly accessible (oEmbed 200). The old `phusionnl/review/…` links were private Vimeo review links; the new ones are public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)