### PR TITLE
Fix NoMethodError in nginx installer after ASan flags split

### DIFF
--- a/bin/passenger-install-nginx-module
+++ b/bin/passenger-install-nginx-module
@@ -549,7 +549,7 @@ private
 
     extra_ldflags = [
       PlatformInfo.openssl_extra_ldflags,
-      boolean_option('USE_ASAN') ? PlatformInfo.address_sanitizer_flags : nil,
+      boolean_option('USE_ASAN') ? PlatformInfo.address_sanitizer_c_ldflags : nil,
     ].compact.join(" ").strip
 
     command = "sh ./configure --prefix='#{prefix}' "


### PR DESCRIPTION
`2498f7598` ("Improve AddressSanitizer support on Linux+Clang, and for dynamically loadable modules") replaced `PlatformInfo.address_sanitizer_flags` with separate `address_sanitizer_cflags` / `_cxxflags` / `_c_ldflags` / `_cxx_ldflags` methods, and updated the callers in `build/*.rb` — but missed `bin/passenger-install-nginx-module:552`.

`USE_ASAN=true` builds of the Nginx integration module therefore fail with:

```
*** EXCEPTION: undefined method `address_sanitizer_flags' for module PhusionPassenger::PlatformInfo (NoMethodError)
```

which is why the **Nginx tests on Linux** and **Nginx tests on macOS** jobs are red on this branch (both fail at "Test installation").

The call site only feeds `--with-ld-opt`, and Nginx is a C codebase, so this uses `address_sanitizer_c_ldflags`. `grep` confirms this was the only remaining reference to the old method name.

### Still failing on this branch (not addressed here)

**C++ tests on Linux** — leaving for @FooBarWidget since it's part of the active ASan work:
- `SystemTools_ProcessMetricsCollectorTest` test 3 (`"PSS is correct"`): the child's PSS exceeds the hard-coded 50–60 MB window under ASan.
- LeakSanitizer: `getaddrinfo`/`generate_addrinfo` allocations via `createNonBlockingTcpSocketConnection` (glibc-internal, likely need suppressions), plus a ~24 KB `mbuf_block_get` leak in the ServerKit accept path (`FdSourceChannel` / `BaseServer::onClientsAccepted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)