### PR TITLE
build: never serve the C++ test precompiled header from a compiler cache

### DIFF
--- a/build/cxx_tests.rb
+++ b/build/cxx_tests.rb
@@ -294,9 +294,8 @@ task 'test:cxx' => cxx_test_dependencies do
 end
 
 file("test/cxx/TestSupport.h.#{PlatformInfo.precompiled_header_extension}" => generate_compilation_task_dependencies('test/cxx/TestSupport.h')) do
-  compile_cxx(
-    "test/cxx/TestSupport.h.#{PlatformInfo.precompiled_header_extension}",
-    'test/cxx/TestSupport.h',
+  target = "test/cxx/TestSupport.h.#{PlatformInfo.precompiled_header_extension}"
+  flags = build_compiler_flags_from_options_or_flags(
     include_paths: test_cxx_include_paths,
     flags: [
       "-x c++-header",
@@ -304,4 +303,16 @@ file("test/cxx/TestSupport.h.#{PlatformInfo.precompiled_header_extension}" => ge
       basic_test_cxx_flags,
     ].compact.flatten
   )
+  ensure_target_directory_exists(target)
+  # The compiler cache does not invalidate this precompiled header when a
+  # header it includes changes -- the generated Constants.h among them -- so it
+  # can hand every test object a PCH built from headers that no longer exist.
+  # It surfaces as a newly added constant being "not declared in this scope" in
+  # the test build only, while the agent, which uses no PCH, compiles against
+  # the same header perfectly well.
+  #
+  # So build it for real every time. It is one compilation, and the objects
+  # that consume it stay cached as before.
+  run_compiler("CCACHE_RECACHE=1 SCCACHE_RECACHE=1 #{cxx} -o #{target} " \
+    "#{EXTRA_PRE_CXXFLAGS} #{flags} #{extra_cxxflags} -c test/cxx/TestSupport.h")
 end


### PR DESCRIPTION
`test/cxx/TestSupport.h.gch` is not invalidated by the compiler cache when a header it *includes* changes. CI can therefore hand every test object a precompiled header built from headers that no longer exist, and the test binary is compiled against a source tree that is partly stale.

## How it shows up

Add a constant to `src/ruby_supportlib/phusion_passenger/constants.rb`, use it from a header that `test/cxx/TestSupport.h` pulls in, and the test build fails with:

```
src/agent/Core/Config.h:509:25: error: 'DEFAULT_ROLLING_RESTART_CONCURRENCY' was not declared in this scope
```

while the same header compiles perfectly well everywhere else. In the run this came from:

* `buildout/support-binaries/CoreMain.o` compiled and `PassengerAgent` linked — the agent uses no PCH and sees the new `Constants.h` fine.
* `Core/ConfigTest.o` and `Watchdog/ApiServerTest.o` failed — both consume the PCH.
* `ApplicationPool/PoolTest.o` compiled fine against other new declarations in `Pool.h`, because `Pool.h` is not in the PCH.
* sccache reported **255 cache hits, 0 cache misses**.
* macOS was green; clang goes through `-include-pch` rather than GCC's `-include` + `-fpch-preprocess`.

Constants.h had already been regenerated correctly, 12 seconds before the PCH was built. The stale header came from the cache, not from the working tree.

## The fix

Build the precompiled header for real every time, with `CCACHE_RECACHE=1 SCCACHE_RECACHE=1`. That is the only change: the command line is otherwise identical, `compile_cxx` is just inlined so the environment can be set for this one invocation.

It is one compilation. The objects that consume the PCH stay cached exactly as before, so the cache hit rate on a normal build is unchanged.

Verified by controlled experiment on the branch where this was found: single-variable change, and the Linux and Valgrind C++ jobs went from failing on the missing constant to green.

## What this does not fix

An object that consumes the PCH has the same gap in its own cache key: `-fpch-preprocess` keeps the PCH's contents out of the preprocessed output that gets hashed, so a *cached* object can also predate a PCH change. That did not bite here — the objects that failed were compiled fresh, because their own sources or dependencies had changed — but it is the same class of problem and worth a look. Closing it properly means mixing a digest of the PCH's dependencies into the command line of both the PCH and its consumers, which invalidates every test object whenever a header inside the PCH changes. That is correct, but it is a bigger trade and belongs in its own change.

## Relation to feec71422

`feec71422` ("Improve precompiled header compatibility with (s)ccache") made the compilations that *consume* the PCH cache-compatible, with `-fpch-preprocess` on GCC and `-fno-pch-timestamp` on clang, per [the ccache manual's precompiled headers section](https://ccache.dev/manual/4.8.2.html#_precompiled_headers). This is the other half: the PCH's own build was left cacheable, and its key does not follow the headers it is built from.

## Where it was found

Building [phusion/passenger-enterprise#7](https://github.com/phusion/passenger-enterprise/pull/7), which adds a constant to `constants.rb`. The bug is in shared build code and applies to both editions, so it is proposed here first. `stable-6.1` has the same `build/cxx_tests.rb` and the same sccache setup.
